### PR TITLE
Enable path completion for "jenv add" in bash

### DIFF
--- a/completions/jenv.bash
+++ b/completions/jenv.bash
@@ -7,9 +7,10 @@ _jenv() {
   else
     local words=("${COMP_WORDS[@]}")
     unset words[0]
-    unset words[$COMP_CWORD]
     local completions=$(jenv completions "${words[@]}")
     COMPREPLY=( $(compgen -W "$completions" -- "$word") )
+    # Prevents the addition of a trailing space when completing a path
+    [[ $COMPREPLY = */ ]] && compopt -o nospace
   fi
 }
 

--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -2,6 +2,13 @@
 set -e
 [ -n "$JENV_DEBUG" ] && set -x
 
+# Provide jenv completions
+if [ "$1" = "--complete" ]; then
+  for d in ${!#}*; do
+    [[ -d "$d" ]] && echo $d/
+  done
+  exit
+fi
 
 
 JENV_JAVAPATH="$1"


### PR DESCRIPTION
This requires that the parameter currently being completed is passed to `jenv completions` instead of being stripped. However, I've looked at all the current implementations of the `--complete` switch and none seems affected by this modification, so I think it's pretty safe.
