### PR TITLE
Updated 'jenv add' instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jenv is for Java,
 5. Configure JVM in jenv
 
 	~~~  sh
-	    $ jenv add oracle-1.7.0 /path/to/java/home
+	    $ jenv add /path/to/java/home
 	~~~
 
 6. Configure which JVM to use (globally, by directory or for the current shell instance)


### PR DESCRIPTION
Updated instructions as per command line output:

```
jenv add alias path/to/java_home is deprecated.
Please let jenv generate unique alias name by using

    $ jenv add path/to/java_home
```
