### PR TITLE
Can't add JDKs when _JAVA_OPTIONS variable is set

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -28,7 +28,7 @@ fi;
 if [ -f "$JENV_JAVAPATH/bin/java" ];
 then     
  
-    JAVA_VERSION=`$JENV_JAVAPATH/bin/java -version 2>&1 | head -n 1 | cut -d\" -f 2 ` 
+    JAVA_VERSION=`$JENV_JAVAPATH/bin/java -version 2>&1 | grep -i 'java version' | cut -d\" -f 2 ` 
 	JAVA_VERSION=${JAVA_VERSION/_/.}   
   
    


### PR DESCRIPTION
Hi,

I noticed I couldn't add JDKs in my environments which set kind of _JAVA_OPTIONS or JAVA_TOOL variable.

The jenv-add script attempts to get the java version from the first line of output of <code>java -version</code> with <code>head -n 1</code>, but in my case, the first line the command gives out is 'Picked up _JAVA_OPTIONS' not 'java version'.
(and I think the command doesn't guarantee that the 'java version' line will be always printed in in the first line.)

I made a small modification to the jenv-add script in order to use <code>grep</code> instead of <code>head</code> to extract the java version.

Thanks.
