### PR TITLE
Replaced ./jenv/bin by ./jenv/shims.

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,10 +85,10 @@ $ brew install jenv</pre>
 				</header>
 				<div class="span9">
 					<h4>Bash</h4>
-						<pre class="code">$ echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.bash_profile
+						<pre class="code">$ echo 'export PATH="$HOME/.jenv/shims:$PATH"' >> ~/.bash_profile
 $ echo 'eval "$(jenv init -)"' >> ~/.bash_profile</pre>
 					<h4>Zsh</h4>
-						<pre class="code">$ echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.zshrc
+						<pre class="code">$ echo 'export PATH="$HOME/.jenv/shims:$PATH"' >> ~/.zshrc
 $ echo 'eval "$(jenv init -)"' >> ~/.zshrc</pre>
 				</div>
 			</article>


### PR DESCRIPTION
jenv executable link is already in hombrew `/usr/local/bin`, but shims are not in the `PATH`, this fixes the installation procedure.
