### PR TITLE
Allow relative paths

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -80,6 +80,9 @@ then
 	then 
 		   cwarn "There is already a $JENV_ALIAS JDK managed by jenv"
 		else
+                        cd $JENV_JAVAPATH
+                        JENV_JAVAPATH=$PWD
+                        cd -
 	 		ln -s  "$JENV_JAVAPATH" "${JENV_ROOT}/versions/$JENV_ALIAS" 
 	 		touch ${JENV_ROOT}/$JENV_ALIAS.time   
 	        cinfo "$JENV_ALIAS added"


### PR DESCRIPTION
This may be a naive way of doing it, but this should fix relative paths.

Currently, if someone is in e.g. `/Library/Java/JavaVirtualMachines/jdk1.7.0_51.jdk/Contents/Home` and uses `jenv add .`, the symlink will be created from `~/.jenv/versions/<version>` to `.` instead of the actual directory.
