### PR TITLE
Fix wrong paths in Fish install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Verified on :
 
 	**Zsh note**: Modify your `~/.zshrc` file instead of `~/.bash_profile`.
 
-    **Fish note**: Modify your `~/.conf/fish/config.sh' to append
+    **Fish note**: Modify your `~/.config/fish/config.fish` to append
     ~~~
         set PATH $HOME/.jenv/bin $PATH
     ~~~
@@ -44,10 +44,10 @@ Verified on :
 
 	_Same as in previous step, use `~/.profile` on Ubuntu, `~/.zshrc` for Zsh._
 
-    **Fish note**: Instead, copy `~/.jenv/fish/jenv.fish` to `~/.conf/fish/function/jenv.fish`. If you don't have the `export` function, also copy `export.fish`
+    **Fish note**: Instead, copy `~/.jenv/fish/jenv.fish` to `~/.config/fish/functions/jenv.fish`. If you don't have the `export` function, also copy `export.fish`.
     ~~~ sh
-        cp ~/.jenv/fish/jenv.fish ~/.conf/fish/function/jenv.fish
-        cp ~/.jenv/fish/export.fish ~/.conf/fish/function/export.fish
+        cp ~/.jenv/fish/jenv.fish ~/.config/fish/functions/jenv.fish
+        cp ~/.jenv/fish/export.fish ~/.config/fish/functions/export.fish
     ~~~
 
 4. Restart your shell as a login shell so the path changes take effect. You can now begin using jenv.


### PR DESCRIPTION
Wrong extension for the fish config file and wrong name for the functions folder in the fish config that fish automatically loads. Also, at least on my Mac OS X 10.9 machine, the folder is `~/.config/`, not `~/.conf`.
