### PR TITLE
In jenv.fish, add flags to `set`s for safety

### DIFF
--- a/fish/jenv.fish
+++ b/fish/jenv.fish
@@ -1,8 +1,8 @@
-set PATH $HOME/.jenv/shims $PATH
+set -gx PATH $HOME/.jenv/shims $PATH
 command jenv rehash 2>/dev/null
 function jenv
-  set cmd $argv[1]
-  set arg ""
+  set -l cmd $argv[1]
+  set -l arg ""
   if test (count $argv) -gt 1
     # Great... fish first array index is ... 1 !
     set arg $argv[2..-1]
@@ -10,7 +10,7 @@ function jenv
 
   switch "$cmd"
     case enable-plugin rehash shell shell-options
-        set script (jenv "sh-$cmd" "$arg")
+        set -l script (jenv "sh-$cmd" "$arg")
         eval $script
     case '*'
         command jenv $cmd $arg


### PR DESCRIPTION
Use `-l` where I can to avoid overwriting any global variable called `cmd`, `arg`, or `script`. I don’t use it for the second `set arg` because it will have already been set, and I’m not sure if the `if` counts as a new scope for `-l` to create a new variable.

I also use `-gx` when setting `PATH` to make it global and export it, just to be sure.
