### PR TITLE
Fix homebrew link, formatting fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,10 @@
 					<h3>What's jEnv ?</h3>
 				</header>
 				<div class="span9 ">
-					<p class="welcome">jEnv is a command line tool to help you forget how to set the JAVA_HOME environment variable</p>
+					<p class="welcome">
+						jEnv is a command line tool to help you forget how to set the
+						JAVA_HOME environment variable
+					</p>
 				</div>
 			</article>
 
@@ -68,9 +71,9 @@
 				</header>
 				<div class="span9">
 					<h4>Linux / OS X</h4>
-						<pre class="code">$ git clone https://github.com/gcuisinier/jenv.git ~/.jenv</pre>
-						<h4>Mac OS X via <a href="http://brew.sh/">Homebrew</a></h4>
-						<pre class="code">$ brew install jenv</pre>
+					<pre class="code">$ git clone https://github.com/gcuisinier/jenv.git ~/.jenv</pre>
+					<h4>Mac OS X via <a href="http://brew.sh/">Homebrew</a></h4>
+					<pre class="code">$ brew install jenv</pre>
 				</div>
 			</article>
 
@@ -122,14 +125,16 @@ $ jenv versions
 						<pre class="code">$ jenv global oracle64-1.6.0.39</pre>
 					<h4>Configure local version (per directory)</h4>
 						<pre class="code">$ jenv local oracle64-1.6.0.39</pre>
-					<h4>Configure shell instance version </h4>
+					<h4>Configure shell instance version</h4>
 						<pre class="code">$ jenv shell oracle64-1.6.0.39</pre>
 				</div>
 			</article>
 
 			<article class="row-fluid">
 				<div class="span12" style="text-align:center">
-					<p class="welcome"><a href="https://github.com/gcuisinier/jenv/wiki">Further Documentation</a></p>
+					<p class="welcome">
+						<a href="https://github.com/gcuisinier/jenv/wiki">Further Documentation</a>
+					</p>
 				</div>
 			</article>
 
@@ -139,20 +144,27 @@ $ jenv versions
 				</header>
 				<div class="span9">
 					<h4>Source code</h4>
-					<p>The project is Open Source and open to external contribution. <br/>Do no hesitate to clone it and propose pull request
-					<ul style="padding-top:10px">
-						<li><i class="icon-arrow-right"></i><a href="https://github.com/gcuisinier/jenv">https://github.com/gcuisinier/jenv</a></li>
-						<li>
-					</ul>
+					<p>
+						The project is Open Source and open to external contributions.
+						<br/>Do no hesitate to clone it and propose a pull request.
 					</p>
+					<ul style="padding-top:10px">
+						<li>
+							<i class="icon-arrow-right"></i>
+							<a href="https://github.com/gcuisinier/jenv">
+								https://github.com/gcuisinier/jenv
+							</a>
+						</li>
+					</ul>
 
-					<h4>Report a issue</h4>
-						<p>You find a bug ? Feature missing in jenv ? Create issue !
+					<h4>Report an issue</h4>
+					<p>Did you find a bug? Feature missing in jenv? Create an issue!</p>
 					<ul style="padding-top:10px">
-						<li><i class="icon-arrow-right"></i><a href="https://github.com/gcuisinier/jenv/issues?state=openv">jEnv issues</a></li>
 						<li>
+							<i class="icon-arrow-right"></i>
+							<a href="https://github.com/gcuisinier/jenv/issues">jEnv issues</a>
+						</li>
 					</ul>
-					</p>
 				</div>
 			</article>
 


### PR DESCRIPTION
I added a closing anchor tag to the homebrew link to prevent it from taking over the rest of the page. There were a few formatting inconsistencies and I tried to fix those as well. The most major change was the change involving multi-line pre blocks from this:

```
<div>
  <div>
    <pre>my code
goes here
and here</pre>
  </div>
</div>
```

To this:

```
<div>
  <div>
<pre>
my code
goes here
and here
</pre>
  </div>
</div>
```

I've included the outer div tags so the change can be seen more clearly. I think this change helps when actually writing the pre blocks so that the entire block of code can be seen as it would be seen in the console. Makes it particularly easy to see when there is stout as well, and helps ensure the distinction between the two can be easily seen.

```
<pre>
$ my_command
  stout: response
$ other_command
  stout: other response
</pre>
```

I've split this into a few commits so you can check each one individually. A few of the commits are pretty much just whitespace changes.

If you like my changes please merge, and if there's something wrong with what I've done, or you disagree with something and want me to change the way I've done it then let me know and I'll be happy to follow your rules.
