### PR TITLE
Run _jenv_export_hook after existing PROMPT_COMMAND

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
@@ -7,7 +7,7 @@
    }
 
 if ! [[ "$PROMPT_COMMAND" =~ _jenv_export_hook ]]; then
-    PROMPT_COMMAND="_jenv_export_hook;$PROMPT_COMMAND";
+    PROMPT_COMMAND="$PROMPT_COMMAND;_jenv_export_hook";
 fi
 
 


### PR DESCRIPTION
Prepending the hook to PROMPT_COMMAND messes up return code reporting.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gcuisinier/jenv/91)

<!-- Reviewable:end -->
