### PR TITLE
Set zsh emulation before running zsh-specific init.

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
@@ -6,11 +6,15 @@
  }
 
 #echo "configure export plugin for ZSH"
+jenv_emulate=`emulate`
+emulate zsh
+
 typeset -ag chpwd_functions
 if [[ -z $chpwd_functions[(r)_jenv_export_hook] ]]; then
       chpwd_functions+=_jenv_export_hook;
 fi
 
+emulate $jenv_emulate
 #export
 
 


### PR DESCRIPTION
Some users prefer to unify their bash and zsh profile variables by having .zprofile reference .profile as follows:

> emulate bash
> . $HOME/.profile
> emulate zsh

This causes export_jenv_hook to fail with "unknown condition: -z" as apparently the if clause uses zsh specific syntax.

This commit forces 'emulate zsh' before executing the zsh init, then returns the emulation settings after the zsh commands.
