### PR TITLE
Propagating error_code on jenv hook

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
@@ -1,16 +1,18 @@
 #export
 
 
- _jenv_export_hook() {
+_jenv_export_hook() {
+  local error_code=$?
   export JAVA_HOME=$(jenv javahome)
   export JENV_FORCEJAVAHOME=true
 
   if [ -e "$JAVA_HOME/bin/javac" ]
   then
-    export JDK_HOME=$(jenv javahome)
+    export JDK_HOME=$JAVA_HOME
     export JENV_FORCEJDKHOME=true
   fi
-   }
+  $(exit $error_code)
+}
 
 if ! [[ "$PROMPT_COMMAND" =~ _jenv_export_hook ]]; then
     PROMPT_COMMAND="_jenv_export_hook;$PROMPT_COMMAND";


### PR DESCRIPTION
Currently error are not propagated, if using plugin export, because the error code gets lost during the evaluation of the JAVA_HOME environment variable.

Currently:

``` bash
$ nonexistent_command
-bash: nonexistent_command: command not found
$ echo $?
0
```

With this PR:

``` bash
$ nonexistent_command
-bash: nonexistent_command: command not found
$ echo $?
127
```

Also includes an optimization to only call jenv once.
