### PR TITLE
Copying rbenv's way of handling rehash for fish

### DIFF
--- a/libexec/jenv-sh-rehash
+++ b/libexec/jenv-sh-rehash
@@ -10,4 +10,12 @@ fi
 # When jenv shell integration is enabled, delegate to jenv-rehash,
 # then tell the shell to empty its command lookup cache.
 jenv-rehash
-echo "hash -r"
+
+case "$shell" in
+fish )
+  # no rehash support
+  ;;
+* )
+  echo "hash -r"
+  ;;
+esac


### PR DESCRIPTION
Fixes part of #152 

Should probably just make other issues for the other fish shell bugs and label em with fish-shell.