### PR TITLE
ZSH completion fixed

### DIFF
--- a/completions/jenv.zsh
+++ b/completions/jenv.zsh
@@ -8,7 +8,7 @@ _jenv() {
   local words completions
   read -cA words
 
-  if [ "${#words}" -eq 2 ]; then
+  if [ "${#words[@]}" -eq 2 ]; then
     completions="$(jenv commands)"
   else
     completions="$(jenv completions ${words[2,-1]})"


### PR DESCRIPTION
The ZSH completion was broken. The following construct was used to check if the number of words on the command line is 2:
```bash
if [ "${#words}" -eq 2 ]
```

`${#words}` returns the number of **characters** in `words` and not the number of words. This results in the following behaviour when pressing \<TAB\>:
```
$ jenv Usage: jenv completions <command> [arg1 arg2...]
 Usage: jenv completions <command> [arg1 arg2...]
  Usage: jenv completions <command> [arg1 arg2...]
  Usage: jenv completions <command> [arg1 arg2...]
```

This was corrected to:
```bash
if [ "${#words[@]}" -eq 2 ]
```
