### PR TITLE
Add fish shell support

### DIFF
--- a/completions/jenv.fish
+++ b/completions/jenv.fish
@@ -1,0 +1,22 @@
+function __fish_jenv_needs_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -eq 1 -a $cmd[1] = 'jenv' ]
+    return 0
+  end
+  return 1
+end
+
+function __fish_jenv_using_command
+  set cmd (commandline -opc)
+  if [ (count $cmd) -gt 1 ]
+    if [ $argv[1] = $cmd[2] ]
+      return 0
+    end
+  end
+  return 1
+end
+
+complete -f -c jenv -n '__fish_jenv_needs_command' -a '(jenv commands)'
+for cmd in (jenv commands)
+  complete -f -c jenv -n "__fish_jenv_using_command $cmd" -a "(jenv completions $cmd)"
+end

--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -22,7 +22,11 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(basename "$SHELL")"
+  shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
+  shell="${shell%% *}"
+  shell="${shell##-}"
+  shell="${shell:-$SHELL}"
+  shell="${shell##*/}"
 fi
 
 resolve_link() {
@@ -56,6 +60,9 @@ if [ -z "$print" ]; then
   ksh )
     profile='~/.profile'
     ;;
+  fish )
+    profile='~/.config/fish/config.fish'
+    ;;
   * )
     profile='your profile'
     ;;
@@ -64,7 +71,14 @@ if [ -z "$print" ]; then
   { echo "# Load jenv automatically by adding"
     echo "# the following to ${profile}:"
     echo
-    echo 'eval "$(jenv init -)"'
+    case "$shell" in
+    fish )
+      echo 'status --is-interactive; and source (jenv init -|psub)'
+      ;;
+    * )
+      echo 'eval "$(jenv init -)"'
+      ;;
+    esac
     echo
   } >&2
 
@@ -73,28 +87,55 @@ fi
 
 mkdir -p "${JENV_ROOT}/"{shims,plugins,versions}
 
-echo 'export PATH="'${JENV_ROOT}'/shims:${PATH}"'
-
 case "$shell" in
+fish )
+  echo "set -gx PATH '${JENV_ROOT}/shims' \$PATH"
+  echo "set -gx JENV_SHELL $shell"
+  echo "set -gx JENV_LOADED 1"
+  echo "set -e JAVA_HOME"
+  ;;
 bash | zsh )
-  echo "source \"$root/completions/jenv.${shell}\""
+  echo 'export PATH="'${JENV_ROOT}'/shims:${PATH}"'
+  echo "export JENV_SHELL=$shell"
+  echo "export JENV_LOADED=1"
+  echo "unset JAVA_HOME"
   ;;
 esac
+
+completion="${root}/completions/jenv.${shell}"
+if [ -r "$completion" ]; then
+  echo "source '$completion'"
+fi
 
 if [ -z "$no_rehash" ]; then
   echo 'jenv rehash 2>/dev/null'
 fi
-
-echo "export JENV_LOADED=1"
-echo "unset JAVA_HOME"
 
 for script in $(jenv-hooks init $shell); do
   echo "source \"$script\""
 done
 
 commands=(`jenv-commands --sh`)
-IFS="|"
-cat <<EOS
+case "$shell" in
+fish )
+  IFS=" "
+  cat <<EOS
+function jenv
+  set command \$argv[1]
+  set -e argv[1]
+
+  switch "\$command"
+  case ${commands[*]}
+    source (jenv "sh-\$command" \$argv|psub)
+  case '*'
+    command jenv "\$command" \$argv
+  end
+end
+EOS
+  ;;
+bash | zsh )
+  IFS="|"
+  cat <<EOS
 jenv() {
   typeset command
   command="\$1"
@@ -110,3 +151,5 @@ jenv() {
   esac
 }
 EOS
+  ;;
+esac


### PR DESCRIPTION

```sh
~ $ fish
~ 🐟 jenv init -
set -gx PATH '/Users/dude/.jenv/shims' $PATH
set -gx JENV_SHELL fish
set -gx JENV_LOADED 1
set -e JAVA_HOME
source '/Users/dude/.jenv/libexec/../completions/jenv.fish'
jenv rehash 2>/dev/null
function jenv
  set command $argv[1]
  set -e argv[1]

  switch "$command"
  case enable-plugin rehash shell shell-options
    source (jenv "sh-$command" $argv|psub)
  case '*'
    command jenv "$command" $argv
  end
end

```

