### PR TITLE
replace hardcoded path in jenv-macos-javahome

### DIFF
--- a/libexec/jenv-macos-javahome
+++ b/libexec/jenv-macos-javahome
@@ -22,7 +22,7 @@ cat << EOT > ${HOME}/Library/LaunchAgents/jenv-environment.plist
      <string>sh</string>
      <string>-c</string>
      <string>
-     launchctl setenv JAVA_HOME $($HOME/.jenv/bin/jenv javahome) ;
+     launchctl setenv JAVA_HOME $(jenv javahome) ;
      </string>
    </array>
    <key>RunAtLoad</key>


### PR DESCRIPTION
Replace a hardcoded call to `$HOME/.jenv/bin/jenv` with a call to the version of jenv that is in the `$PATH`.

This fixes an error when JENV is installed through homebrew.  (Fixes #230)

Alternatively this file could be edited during the brew installation to point to the path in Cellar.  I can close this and open a homebrew PR if that's the preferred way to do it.