### PR TITLE
Fixes #234 : install the hook within a local function

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
@@ -12,17 +12,13 @@
  }
 
 #echo "configure export plugin for ZSH"
-jenv_emulate=`emulate`
-emulate zsh
-
-typeset -ag chpwd_functions
-if [[ -z $chpwd_functions[(r)_jenv_export_hook] ]]; then
-      chpwd_functions+=_jenv_export_hook;
-fi
-
-emulate $jenv_emulate
-#export
-
-
+function install_hook {
+  emulate -LR zsh
+  typeset -ag chpwd_functions
+  if [[ -z $chpwd_functions[(r)_jenv_export_hook] ]]; then
+        chpwd_functions+=_jenv_export_hook;
+  fi
+}
+install_hook
 
 _jenv_export_hook


### PR DESCRIPTION
The previous code started a _new_ emulation, which had the side effect 
of resetting some options like `auto_cd`.

> If the -R switch is given, all settable options are reset to their default value corresponding to the specified emulation mode, except for certain options describing the interactive environment; **otherwise, only those options likely to cause portability problems in scripts and functions are altered.**

Source : http://zsh.sourceforge.net/Doc/Release/Shell-Builtin-Commands.html#Shell-Builtin-Commands