### PR TITLE
Fix regression in `jenv add` introduced in 0617e57

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -82,7 +82,7 @@ fi;
 if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
     if [ -z "${JENV_ALIAS}" ]; then
         JAVA_VERSION_OUTPUT=`"${JENV_JAVAPATH}"/bin/java -version 2>&1`
-        JAVA_VERSION=`"${JENV_JAVAPATH}"/bin/java -version 2>&1 | head -n 1 | cut -d\" -f 2 `
+        JAVA_VERSION=`"${JENV_JAVAPATH}"/bin/java -version 2>&1 | grep 'version' | head -n 1 | cut -d\" -f 2 `
         JAVA_VERSION=${JAVA_VERSION/_/.}
 
         case "${JAVA_VERSION_OUTPUT}" in


### PR DESCRIPTION
An issue regarding `JAVA_TOOL_OPTIONS` (#118), which was already [fixed](https://github.com/jenv/jenv/commit/a823349576dd3735d7ac58a185702aa3c91133d2), has been [re-introduced](https://github.com/jenv/jenv/commit/0617e57fd7e7d040c041b6c6777f011420e193a9#diff-d470885dc7f9c809eacff6b6dc7dce36R87).

This PR fixes that regression.

Supersedes #156.