### PR TITLE
Fixes #165, changes the export-plugin for zsh to act like the bash plugin

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
@@ -14,9 +14,9 @@
 #echo "configure export plugin for ZSH"
 function install_hook {
   emulate -LR zsh
-  typeset -ag chpwd_functions
-  if [[ -z $chpwd_functions[(r)_jenv_export_hook] ]]; then
-        chpwd_functions+=_jenv_export_hook;
+  typeset -ag precmd_functions
+  if [[ -z $precmd_functions[(r)_jenv_export_hook] ]]; then
+        precmd_functions+=_jenv_export_hook;
   fi
 }
 install_hook


### PR DESCRIPTION
Changes the `export-plugin` hook for zsh to act before the prompt is shown as it does with bash.

Without this change, if you do not open a new shell or change directories, `JAVA_HOME` will not update

Fixes #165 