### PR TITLE
fix graalvm JAVA_PROVIDER detection for jenv-add

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -90,9 +90,9 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
             *Zulu*)         JAVA_PROVIDER="zulu" ;;
             *GraalVM*)      JAVA_PROVIDER="graalvm" ;;
             *Corretto*)     JAVA_PROVIDER="corretto" ;;
-            *OpenJDK*)      JAVA_PROVIDER="openjdk" ;;
             *J9*)           JAVA_PROVIDER="ibm" ;;
             *SAP*)          JAVA_PROVIDER="sap" ;;
+            *OpenJDK*)      JAVA_PROVIDER="openjdk" ;;
             *)              JAVA_PROVIDER="other" ;;
         esac
     fi;

--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -88,10 +88,11 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
         case "${JAVA_VERSION_OUTPUT}" in
             *HotSpot*)      JAVA_PROVIDER="oracle" ;;
             *Zulu*)         JAVA_PROVIDER="zulu" ;;
+            *GraalVM*)      JAVA_PROVIDER="graalvm" ;;
+	    *Corretto*)     JAVA_PROVIDER="corretto" ;;
             *OpenJDK*)      JAVA_PROVIDER="openjdk" ;;
             *J9*)           JAVA_PROVIDER="ibm" ;;
             *SAP*)          JAVA_PROVIDER="sap" ;;
-            *GraalVM*)      JAVA_PROVIDER="graalvm" ;;
             *)              JAVA_PROVIDER="other" ;;
         esac
     fi;

--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -89,7 +89,7 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
             *HotSpot*)      JAVA_PROVIDER="oracle" ;;
             *Zulu*)         JAVA_PROVIDER="zulu" ;;
             *GraalVM*)      JAVA_PROVIDER="graalvm" ;;
-	    *Corretto*)     JAVA_PROVIDER="corretto" ;;
+            *Corretto*)     JAVA_PROVIDER="corretto" ;;
             *OpenJDK*)      JAVA_PROVIDER="openjdk" ;;
             *J9*)           JAVA_PROVIDER="ibm" ;;
             *SAP*)          JAVA_PROVIDER="sap" ;;


### PR DESCRIPTION
`GraalVM` includes `OpenJDK` in it's `java -version` output: 

```
openjdk version "1.8.0_212"
OpenJDK Runtime Environment (build 1.8.0_212-20190420112649.buildslave.jdk8u-src-tar--b03)
OpenJDK GraalVM CE 19.0.0 (build 25.212-b03-jvmci-19-b01, mixed mode)
```
so it needs to be an earlier check to get picked up correctly so it isn't incorrectly set to `openjdk`.

Additionally, added detection for Amazon Corretto which outputs `java -version` as:
```
openjdk version "1.8.0_212"
OpenJDK Runtime Environment Corretto-8.212.04.2 (build 1.8.0_212-b04)
OpenJDK 64-Bit Server VM Corretto-8.212.04.2 (build 25.212-b04, mixed mode)
```