### PR TITLE
Made export plugin work with fish shell

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
@@ -1,0 +1,13 @@
+#export
+
+function jenv_set_java_home_preexec --on-event fish_preexec
+    set -gx JAVA_HOME (jenv javahome)
+    set -gx JENV_FORCEJAVAHOME true
+
+    if test -e "$JAVA_HOME/bin/javac"
+        set -gx JDK_HOME "$JAVA_HOME"
+        set -gx JENV_FORCEJAVAHOME true
+    end
+end
+
+jenv_set_java_home_preexec

--- a/libexec/jenv-hooks
+++ b/libexec/jenv-hooks
@@ -57,6 +57,11 @@ for path in ${JENV_HOOK_PATH//:/$'\n'}; do
     echo $(realpath $script)
   done
     ;;
+  fish )
+    for script in $path/"$JENV_COMMAND"/*.fish; do
+    echo $(realpath $script)
+  done
+    ;;
   esac
 
   


### PR DESCRIPTION
This PR enables loading of fish scripts if the current shell is fish, and adds a fish initialization script for the export plugin to work correctly.