### PR TITLE
Add Java path basename as an alias.

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -110,6 +110,8 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
 
     JAVA_SHORTVERSION=$(sed 's/\([0-9].[0-9]\).*/\1/' <<< $JAVA_VERSION)
 
+    JAVA_BASENAME=$(basename ${JENV_JAVAPATH})
+    add_alias_check $JAVA_BASENAME
     add_alias_check $JENV_ALIAS
     add_alias_check $JAVA_VERSION
 


### PR DESCRIPTION
For a variety of reasons, I needed a means to identify a specific _Java_ installation directory based upon the name of that directory, rather than its version information. This _PR_ modifies the `jenv add` command to create an alias that is the _basename_ of the path to the added _Java_ installation.

The _basename_ can also be a symbolic link to a specific _Java_ installation, for added flexibiliy.

For example:

```bash
$ jenv add /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64
adoptopenjdk-8-hotspot-amd64 added
openjdk64-1.8.0.212 added
1.8.0.212 added
1.8 added
```

The only issue I can foresee are clashes with the resulting additional aliases, but this is a latest issue with the `jenv` alias creation code.