### PR TITLE
Update README.md for fish shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ Continue to the next section to install java.
 **Untested**: While this fork has improved `fish` shell support, it has not been tested by this maintainer. To install `jenv` for Fish according to the contributor's instructions:
 
 ```sh
-echo 'set PATH $HOME/.jenv/bin $PATH' >> ~/.conf/fish/config.sh
-cp ~/.jenv/fish/jenv.fish ~/.conf/fish/function/jenv.fish
-cp ~/.jenv/fish/export.fish ~/.conf/fish/function/export.fish
+echo 'set PATH $HOME/.jenv/bin $PATH' >> ~/.config/fish/config.fish
+echo 'status --is-interactive; and source (jenv init -|psub)' >> ~/.config/fish/config.fish
+cp ~/.jenv/fish/jenv.fish ~/.config/fish/function/jenv.fish
+cp ~/.jenv/fish/export.fish ~/.config/fish/function/export.fish
 ```
 
 #### 1.2 Adding Your Java Environment


### PR DESCRIPTION
When I use
```
jenv init
```
in fish I get
```
# Load jenv automatically by adding
# the following to ~/.config/fish/config.fish:

status --is-interactive; and source (jenv init -|psub)
```