### PR TITLE
Correcting `jenv help` Github link to the correct Github README.md

### DIFF
--- a/libexec/jenv-help
+++ b/libexec/jenv-help
@@ -146,7 +146,7 @@ if [ -z "$1" ] || [ "$1" == "jenv" ]; then
   print_summaries commands local global shell install uninstall rehash version versions which whence add
   echo
   echo "See \`jenv help <command>' for information on a specific command."
-  echo "For full documentation, see: https://github.com/hikage/jenv#readme"
+  echo "For full documentation, see: https://github.com/jenv/jenv/blob/master/README.md"
 else
   command="$1"
   if [ -n "$(command_path "$command")" ]; then


### PR DESCRIPTION
Not sure if the front page, the readme file in master, or the JENV website is the best place to update the link to, but I believe this is the best option.