### PR TITLE
Fixes #193 ZSH completion do not add the space anymore

### DIFF
--- a/completions/jenv.zsh
+++ b/completions/jenv.zsh
@@ -2,7 +2,7 @@ if [[ ! -o interactive ]]; then
     return
 fi
 
-compctl -K _jenv jenv
+compctl -S "" -K _jenv jenv
 
 _jenv() {
   local words completions


### PR DESCRIPTION
The trick is done by configuring compctl to suffix the completion with nothing (`-S ""`).

http://zsh.sourceforge.net/Doc/Release/Completion-Using-compctl.html#Control-Flags

> `-S suffix`
>
>    When a completion is found the suffix is inserted after the completed string. In the case of menu completion the suffix is inserted immediately, but it is still possible to cycle through the list of completions by repeatedly hitting the same key.

The only downside though is that now after selecting a completion, one has to manually enter a space.

This would be nice improvement to fix #193