### PR TITLE
Fix the warn msg

### DIFF
--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -95,7 +95,7 @@ else
   esac
 
   cwarn "Jenv is not loaded in your $shell"
-  cwarn 'To fix : \tcat eval "$(jenv init -)" >>' $profile
+  cwarn 'To fix : \techo eval "$(jenv init -)" >>' $profile
 
 
 


### PR DESCRIPTION
I'm installing the jEnv on Mac OSX with Homebrew.
```
$ brew install jenv
# restart the terminal
$ jenv doctor
```
After run the commands above, it gives the following message:
```
[OK]	No JAVA_HOME set
[ERROR]	Java binary in path is not in the jenv shims.
[ERROR]	Please check your path, or try using /path/to/java/home is not a valid path to java installation.
	PATH : /usr/local/Cellar/jenv/0.5.2/libexec/libexec:/Users/maxpeng/.cargo/bin:/Users/maxpeng/.pyenv/shims:/Users/username/.pyenv:/Users/maxpeng/.nvm/versions/node/v8.11.4/bin:/Users/maxpeng/bin:/usr/local/bin:/Users/maxpeng/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Users/maxpeng/Documents/Projects/golang/bin
[ERROR]	Jenv is not loaded in your zsh
[ERROR]	To fix : 	cat eval "$(jenv init -)" >> /Users/xxx/.zshrc
```
The last sentence is not correct, which should be `echo eval "$(jenv init -)" >> /Users/xxx/.zshrc`

Please correct me if I'm wrong.