### PR TITLE
Fix SapMachine detection for new output style.

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -91,6 +91,7 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
             *GraalVM*)      JAVA_PROVIDER="graalvm" ;;
             *Corretto*)     JAVA_PROVIDER="corretto" ;;
             *J9*)           JAVA_PROVIDER="ibm" ;;
+            *sapmachine*)   JAVA_PROVIDER="sap" ;;
             *SAP*)          JAVA_PROVIDER="sap" ;;
             *OpenJDK*)      JAVA_PROVIDER="openjdk" ;;
             *)              JAVA_PROVIDER="other" ;;


### PR DESCRIPTION
Example of what breaks the existing check:

```shellsession
$ /Library/Java/JavaVirtualMachines/sapmachine-jdk-13.0.2.jdk/Contents/Home/bin/java -version
openjdk version "13.0.2" 2020-01-16
OpenJDK Runtime Environment (build 13.0.2+8-sapmachine)
OpenJDK 64-Bit Server VM (build 13.0.2+8-sapmachine, mixed mode, sharing)
```