### PR TITLE
sync JDK_HOME with JAVA_HOME

### DIFF
--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -93,12 +93,14 @@ fish )
   echo "set -gx JENV_SHELL $shell"
   echo "set -gx JENV_LOADED 1"
   echo "set -e JAVA_HOME"
+  echo "set -e JDK_HOME"
   ;;
 bash | zsh )
   echo 'export PATH="'${JENV_ROOT}'/shims:${PATH}"'
   echo "export JENV_SHELL=$shell"
   echo "export JENV_LOADED=1"
   echo "unset JAVA_HOME"
+  echo "unset JDK_HOME"
   ;;
 esac
 


### PR DESCRIPTION
Keep JDK_HOME environment variable in sync with JAVA_HOME to avoid discrepancies within the same (i.e. not new or reloaded) shell whenever `jenv init -` is being executed.