### PR TITLE
Add fish hook for prompt

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
@@ -1,0 +1,10 @@
+# load jenv and enable export hook
+function __jenv_export_hook --on-event fish_prompt
+  set -gx JAVA_HOME (jenv javahome)
+  set -gx JENV_FORCEJAVAHOME true
+
+  if test -e "$JAVA_HOME/bin/javac"
+    set -gx JDK_HOME "$JAVA_HOME"
+    set -gx JENV_FORCEJDKHOME true
+  end
+end

--- a/libexec/jenv-hooks
+++ b/libexec/jenv-hooks
@@ -46,7 +46,7 @@ realpath() {
 shopt -s nullglob
 for path in ${JENV_HOOK_PATH//:/$'\n'}; do
 
-   case "$shell" in
+  case "$shell" in
   bash )
     for script in $path/"$JENV_COMMAND"/*.bash; do
     echo $(realpath $script)
@@ -55,9 +55,14 @@ for path in ${JENV_HOOK_PATH//:/$'\n'}; do
   zsh )
     for script in $path/"$JENV_COMMAND"/*.zsh; do
     echo $(realpath $script)
-  done
+    done 
     ;;
-  esac
+  fish )
+    for script in $path/"$JENV_COMMAND"/*.fish; do
+    echo $(realpath $script)
+    done
+    ;;
+esac
 
   
 done


### PR DESCRIPTION
Ensures that JAVA_HOME is set properly and that prompts get correct info on current java version.

From https://github.com/jenv/jenv/issues/188#issuecomment-605761423

Fixes #188