### PR TITLE
Fix the custom alias functionality

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -77,6 +77,12 @@ if [ "$#" -eq 2 ]; then
 	JENV_JAVAPATH="$2"
 	JENV_ALIAS="$1"
 
+    add_alias_check $JENV_ALIAS
+    if $version_added ; then
+        $(jenv-rehash)
+    fi;
+
+    exit 0
 fi;
 
 if [ -f "${JENV_JAVAPATH}/bin/java" ]; then


### PR DESCRIPTION
Currently the custom alias functionality is not only deprecated, but broken. For example,

```
$ jenv add test-me /home/avorona/code/openjdk-jdk14u/build/linux-x86_64-server-release/jdk/
Warning : jenv add alias path/to/java_home is deprecated.
Please prefer to let jenv generate unique alias name by using

    $ jenv add path/to/java_home

64- added
 added
```

Those are not the versions the user intended to add at all.

This Pull Requests fixes the alias functionality, but *keeps it deprecated*.

Sample usage:
```
$ jenv add test-me /home/avorona/code/openjdk-jdk14u/build/linux-x86_64-server-release/jdk/
Warning : jenv add alias path/to/java_home is deprecated.
Please prefer to let jenv generate unique alias name by using

    $ jenv add path/to/java_home

test-me added

$ jenv add 14.0.1-dev-local-build /home/avorona/code/openjdk-jdk14u/build/linux-x86_64-server-release/jdk/
Warning : jenv add alias path/to/java_home is deprecated.
Please prefer to let jenv generate unique alias name by using

    $ jenv add path/to/java_home

14.0.1-dev-local-build added
```

In my use case it is common for me to have various builds of the JVMs locally that do not differ in their version string at all. I know that I can change the version suffix (`-internal` be default) and keep them separate that way, but I often forget and need to rebuild the openjdk for the change to take effect, and this takes long time.

The change is minimal and the deprecation warning is still there, since I agree that for the most users of `jenv` parsing the version string is by far the best way to go.

This addresses issues #303, #68, #223, #268
```