### PR TITLE
fix: Allow fish to use jenv export plugin in non-interactive shells

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
@@ -1,5 +1,5 @@
 # load jenv and enable export hook
-function __jenv_export_hook --on-event fish_prompt
+function __jenv_export_hook  --on-variable PWD
   set -gx JAVA_HOME (jenv javahome)
   set -gx JENV_FORCEJAVAHOME true
 


### PR DESCRIPTION
The current event handler is listening for the prompt to print; doesn't handle non-interactive shells.