### PR TITLE
B/fix fish shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,51 +2,67 @@
 
 Website : http://www.jenv.be
 
-Maintainers : 
+Maintainers :
+
 - [Gildas Cuisinier](https://github.com/gcuisinier/)
 
 Future maintainer in discussion:
-- [Benjamin Berman](https://github.com/doctorpangloss) 
 
-As he makes an incredible work by taking time to merge the Pull Request on his fork, I (@gcuisinier) am in discussion with him to take part of jEnv directly if he wants.
-Whatever his decision, I thank him for his work, and to have convincing me to think about the future of jEnv and accepting a new maintainer for the good of the project.
+- [Benjamin Berman](https://github.com/doctorpangloss)
+
+As he makes an incredible work by taking time to merge the Pull Request on his
+fork, I (@gcuisinier) am in discussion with him to take part of jEnv directly if
+he wants. Whatever his decision, I thank him for his work, and to have
+convincing me to think about the future of jEnv and accepting a new maintainer
+for the good of the project.
 
 ## What's jEnv ?
 
-This is an updated fork of `jenv`, a beloved Java environment manager adapted from `rbenv`.
+This is an updated fork of `jenv`, a beloved Java environment manager adapted
+from `rbenv`.
 
-`jenv` gives you a few critical affordances for using `java` on development machines:
+`jenv` gives you a few critical affordances for using `java` on development
+machines:
 
- - It lets you switch between `java` versions. This is useful when developing Android applications, which generally require Java 8 for its tools, versus server applications, which use later versions like Java 11.
- - It sets `JAVA_HOME` inside your shell, in a way that can be set globally, local to the current working directory or per shell.
+- It lets you switch between `java` versions. This is useful when developing
+  Android applications, which generally require Java 8 for its tools, versus
+  server applications, which use later versions like Java 11.
+- It sets `JAVA_HOME` inside your shell, in a way that can be set globally,
+  local to the current working directory or per shell.
 
 However, this project does **not**:
 
- - Install `java` for you. Use your platform appropriate package manager to install `java`. On macOS, `brew` is recommended.
+- Install `java` for you. Use your platform appropriate package manager to
+  install `java`. On macOS, `brew` is recommended.
 
-This document will show you how to install `jenv`, review its most common commands, show example workflows and identify known issues.
+This document will show you how to install `jenv`, review its most common
+commands, show example workflows and identify known issues.
 
 ### Contents
 
- 1. [Getting Started](#1-getting-started)
- 2. [Example Workflows](#2-common-workflows)
- 3. [Known Issues](#3-known-issues)
+1.  [Getting Started](#1-getting-started)
+1.  [Example Workflows](#2-common-workflows)
+1.  [Known Issues](#3-known-issues)
 
 ### 1. Getting Started
 
-Follow the steps below to get a working `jenv` installation with knowledge of your `java` environment. Read all the code you execute carefully: a `$` symbol at the beginning of a line should be omitted, since it's meant to show you entering a command into your terminal and observing the response after the command.
+Follow the steps below to get a working `jenv` installation with knowledge of
+your `java` environment. Read all the code you execute carefully: a `$` symbol
+at the beginning of a line should be omitted, since it's meant to show you
+entering a command into your terminal and observing the response after the
+command.
 
 #### 1.1 Installing `jenv`
 
 On OSX, the simpler way to install jEnv is using [Homebrew](https://brew.sh)
 
-```bash
+```sh
 brew install jenv
 ```
 
 Alternatively, and on Linux, you can install it from source :
 
-```bash
+```sh
 git clone https://github.com/jenv/jenv.git ~/.jenv
 # Shell: bash
 echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.bash_profile
@@ -54,18 +70,24 @@ echo 'eval "$(jenv init -)"' >> ~/.bash_profile
 # Shell: zsh
 echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.zshrc
 echo 'eval "$(jenv init -)"' >> ~/.zshrc
+# Shell: fish
+echo 'set PATH $HOME/.jenv/bin $PATH' >> ~/.config/fish/config.fish
+echo 'jenv init - fish | source' >> ~/.config/fish/config.fish
+cp ~/.jenv/fish/jenv.fish ~/.config/fish/functions/jenv.fish
 ```
 
-Restart your shell by closing and reopening your terminal window or running `exec $SHELL -l` in the current session for the changes to take effect.
+Restart your shell by closing and reopening your terminal window or running
+`exec $SHELL -l` in the current session for the changes to take effect.
 
-To verify `jenv` was installed, run `jenv doctor`. On a macOS machine, you'll observe the following output:
+To verify `jenv` was installed, run `jenv doctor`. On a macOS machine, you'll
+observe the following output:
 
-```bash
+```sh
 $ jenv doctor
 [OK]	No JAVA_HOME set
 [ERROR]	Java binary in path is not in the jenv shims.
 [ERROR]	Please check your path, or try using /path/to/java/home is not a valid path to java installation.
-	PATH : /Users/user/.jenv/libexec:/Users/user/.jenv/shims:/Users/user/.jenv/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+  PATH : /Users/user/.jenv/libexec:/Users/user/.jenv/shims:/Users/user/.jenv/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 [OK]	Jenv is correctly loaded
 ```
 
@@ -73,42 +95,37 @@ Observe that `jenv` is correctly loaded but Java is not yet installed.
 
 To make sure `JAVA_HOME` is set, make sure to enable the `export` plugin:
 
-```bash
+```sh
 jenv enable-plugin export
 exec $SHELL -l
 ```
 
-Problem? Please visit the [Trouble Shooting](https://github.com/jenv/jenv/wiki/Trouble-Shooting) Wiki page.
+Problem? Please visit the
+[Trouble Shooting](https://github.com/jenv/jenv/wiki/Trouble-Shooting) Wiki
+page.
 
 Continue to the next section to install java.
 
-
-
-**Untested**: While this fork has improved `fish` shell support, it has not been tested by this maintainer. To install `jenv` for Fish according to the contributor's instructions:
-
-```sh
-echo 'set PATH $HOME/.jenv/bin $PATH' >> ~/.config/fish/config.fish
-echo 'status --is-interactive; and source (jenv init -|psub)' >> ~/.config/fish/config.fish
-cp ~/.jenv/fish/jenv.fish ~/.config/fish/functions/jenv.fish
-cp ~/.jenv/fish/export.fish ~/.config/fish/functions/export.fish
-```
-
 #### 1.2 Adding Your Java Environment
 
-Use `jenv add` to inform `jenv` where your Java environment is located. `jenv` does not, by itself, install Java.
+Use `jenv add` to inform `jenv` where your Java environment is located. `jenv`
+does not, by itself, install Java.
 
-For example, on macOS, use `brew` to install the latest Java (OpenJDK 11) followed by the appropriate `jenv add PATH_TO_JVM_HOME` command to recognize it.
+For example, on macOS, use `brew` to install the latest Java (OpenJDK 11)
+followed by the appropriate `jenv add PATH_TO_JVM_HOME` command to recognize it.
 
-```bash
+```sh
 brew cask install java
 jenv add $(/usr/libexec/java_home)
 ```
 
-With macOS OpenJDK 11.0.2 installed, for example, either of these commands will add `/Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home` as a valid JVM. Your JVM directory may vary!
+With macOS OpenJDK 11.0.2 installed, for example, either of these commands will
+add `/Library/Java/JavaVirtualMachines/openjdk-11.0.2.jdk/Contents/Home` as a
+valid JVM. Your JVM directory may vary!
 
 Observe now that this version of Java is added to your `java versions` command:
 
-```bash
+```sh
 $ jenv versions
 * system (set by /Users/user/.jenv/version)
   11.0
@@ -118,7 +135,10 @@ $ jenv versions
 
 By default, the latest version of Java is your `system` Java on macOS.
 
-We'll now set a `jenv local VERSION` local Java version for the current working directory. This will create a `.java-version` file we can check into Git for our projects, and `jenv` will load it correctly **when a shell is started from this directory**.
+We'll now set a `jenv local VERSION` local Java version for the current working
+directory. This will create a `.java-version` file we can check into Git for our
+projects, and `jenv` will load it correctly **when a shell is started from this
+directory**.
 
 ```bash
 $ jenv local 11.0.2
@@ -134,11 +154,14 @@ $ echo ${JAVA_HOME}
 /Users/bberman/.jenv/versions/11.0.2
 ```
 
-Yes! Observe that `JAVA_HOME` is set to a valid shim directory. Unlike the main repository's documentation we helpfully installed the `export` plugin, and we now have the most important `jenv` features covered.
+Yes! Observe that `JAVA_HOME` is set to a valid shim directory. Unlike the main
+repository's documentation we helpfully installed the `export` plugin, and we
+now have the most important `jenv` features covered.
 
-If you executed this commands inside your `$HOME` directory, you can now delete `.java-version`:
+If you executed this commands inside your `$HOME` directory, you can now delete
+`.java-version`:
 
-```bash
+```sh
 rm .java-version
 ```
 
@@ -146,20 +169,24 @@ rm .java-version
 
 Use `jenv global VERSION` to set a global Java version:
 
-```bash
+```sh
 jenv global 11.0.2
 ```
 
-When you next open a shell or terminal window, this version of Java will be the default.
+When you next open a shell or terminal window, this version of Java will be the
+default.
 
-On macOS, this sets `JAVA_HOME` for GUI applications on macOS using `jenv macos-javahome`. Integrates [this tutorial](https://www.ibm.com/support/knowledgecenter/en/SSPJLC_7.6.2/com.ibm.si.mpl.doc/tshoot/ts_java_home.html) to create a file that does **not update dynamically** depending on what local or shell version of Java is set, only global.
-
+On macOS, this sets `JAVA_HOME` for GUI applications on macOS using
+`jenv macos-javahome`. Integrates
+[this tutorial](https://www.ibm.com/support/knowledgecenter/en/SSPJLC_7.6.2/com.ibm.si.mpl.doc/tshoot/ts_java_home.html)
+to create a file that does **not update dynamically** depending on what local or
+shell version of Java is set, only global.
 
 #### 1.4 Setting a Shell Java Version
 
 Use `jenv shell VERSION` to set the Java used in this particular shell session:
 
-```bash
+```sh
 jenv shell 11.0.2
 ```
 
@@ -169,26 +196,34 @@ These common workflows demonstrate how to use `jenv` to solve common problems.
 
 #### 2.1 Using Two JVMs on macOS
 
-Our goal is to have both the latest version of Java and JDK 8 installed at the same time. This is helpful for developing Android applications, whose build tools are sensitive to using an exact Java version.
+Our goal is to have both the latest version of Java and JDK 8 installed at the
+same time. This is helpful for developing Android applications, whose build
+tools are sensitive to using an exact Java version.
 
-We'll resume where we left off with Java 11.0.2 installed. Let's [install Java 8](https://stackoverflow.com/questions/24342886/how-to-install-java-8-on-mac) now:
+We'll resume where we left off with Java 11.0.2 installed. Let's
+[install Java 8](https://stackoverflow.com/questions/24342886/how-to-install-java-8-on-mac)
+now:
 
-```bash
+```sh
 brew cask install adoptopenjdk8
 brew cask install caskroom/versions/adoptopenjdk8
 ```
 
-This will install the latest version of Java 8 to a special directory in macOS. Let's see which directory that is:
+This will install the latest version of Java 8 to a special directory in macOS.
+Let's see which directory that is:
 
-```bash
-$ ls -1 /Library/Java/JavaVirtualMachines 
+```sh
+$ ls -1 /Library/Java/JavaVirtualMachines
 adoptopenjdk-8.jdk
 openjdk-11.0.2.jdk
 ```
 
-Observe the `adoptopenjdk-8.jdk` directory. **Your exact version may vary**. We cannot retrieve this using `/usr/libexec/java_home`, unfortunately. We'll add the Java home directory using `jenv` so that it shows up in our `jenv versions` command:
+Observe the `adoptopenjdk-8.jdk` directory. **Your exact version may vary**. We
+cannot retrieve this using `/usr/libexec/java_home`, unfortunately. We'll add
+the Java home directory using `jenv` so that it shows up in our `jenv versions`
+command:
 
-```bash
+```sh
 $ jenv add /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/
 openjdk64-1.8.0.222 added
 1.8.0.222 added
@@ -211,7 +246,3 @@ Please contribute your own using a pull request!
 ### 3 Known Issues
 
 Users seem to have issues using `jenv` with Fish. Please report any here.
-
-
-
-

--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
@@ -1,5 +1,5 @@
 # load jenv and enable export hook
-function __jenv_export_hook --on-event fish_prompt
+function __jenv_export_hook  --on-variable PWD
   set -gx JAVA_HOME (jenv javahome)
   set -gx JENV_FORCEJAVAHOME true
 

--- a/fish/export.fish
+++ b/fish/export.fish
@@ -1,4 +1,0 @@
-function export
-  set arr (echo $argv|tr = \n)
-  set -gx $arr[1] $arr[2]
-end

--- a/fish/jenv.fish
+++ b/fish/jenv.fish
@@ -1,18 +1,16 @@
-set PATH $HOME/.jenv/shims $PATH
-command jenv rehash 2>/dev/null
-function jenv
-  set cmd $argv[1]
-  set arg ""
-  if test (count $argv) -gt 1
-    # Great... fish first array index is ... 1 !
-    set arg $argv[2..-1]
-  end
+function jenv -w jenv --description "Wrapper function for jenv to work with fish shell"
+    set cmd $argv[1]
+    set arg ""
+    if test (count $argv) -gt 1
+        # Great... fish first array index is ... 1 !
+        set arg $argv[2..-1]
+    end
 
-  switch "$cmd"
-    case enable-plugin rehash shell shell-options
-        set script (jenv "sh-$cmd" "$arg")
-        eval $script
-    case '*'
-        command jenv $cmd $arg
+    switch "$cmd"
+        case enable-plugin rehash shell shell-options
+            set script (jenv "sh-$cmd" "$arg")
+            eval $script
+        case '*'
+            command jenv $cmd $arg
     end
 end


### PR DESCRIPTION
Remove export.fish, as fish shell ships with an export function as of 3.x
Update documentation and reformat
Update jenv wrapper function to improve compatibility
Handle non-interactive shells