### PR TITLE
Update jenv-add To Handle Versions With No '.'

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -118,7 +118,7 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
     JENV_ALIAS="${JAVA_PROVIDER}${JAVA_PLATFORM}-${JAVA_VERSION}"
 
     JAVA_SHORTVERSION=$(sed 's/\([0-9]\.[0-9]\).*/\1/' <<< $JAVA_VERSION)
-    JAVA_SHORTESTVERSION=$(sed 's/\([0-9]\)\..*/\1/' <<< $JAVA_VERSION)
+    JAVA_SHORTESTVERSION=$(sed 's/\([0-9]\+\)\.\?.*/\1/' <<< $JAVA_VERSION)
 
     add_alias_check $JENV_ALIAS
     add_alias_check $JAVA_VERSION


### PR DESCRIPTION
This commit updates `jenv-add` to handle version numbers which are > 1.8 and do not include a `.` _but may include a non-numeric suffix_. For example, this is the case when installing JDK15 on Ubuntu 20.04 LTS from the Canonical PPA. In this case the version number parsed by `jenv` is `15-ea` ("ea" is for early adopter I believe).

The old `jenv` logic would only parse a single alias for this JRE, the full string `15-ea`. This is especially undesirable since the `-ea` suffix is likely to go away in the near future, either via PPA updates or distro updates.

This commit updates the `sed` call which parses `JAVA_SHORTESTVERSION` to look for an _optional_ `.`, rather than a required one.

For example,

```shell
$ sed 's/\([0-9]\+\).*/\1/' <<< 15-ea
15
```

This change _should_ not change other existing parsing behavior, e.g.

```shell
$ sed 's/\([0-9]\+\).*/\1/' <<< '1.8.0'
1
```

```shell
$ sed 's/\([0-9]\+\).*/\1/' <<< '14.0.1'
14
```