### PR TITLE
Silence fish export hook if jenv not in path

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
@@ -1,5 +1,8 @@
 # load jenv and enable export hook
 function __jenv_export_hook --on-event fish_prompt
+  if not command -s jenv
+    return
+  end
   set -gx JAVA_HOME (jenv javahome)
   set -gx JENV_FORCEJAVAHOME true
 


### PR DESCRIPTION
If jenv isn't in PATH when the hook runs, fish throws a fit, with a few lines of error messages per prompt. This is an edge case, but it's annoying when it does happen.