### PR TITLE
Update readme with new jenv install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Our goal is to have both the latest version of Java and JDK 8 installed at the s
 
 We'll resume where we left off with Java 11.0.2 installed. Let's [install Java 8](https://stackoverflow.com/questions/24342886/how-to-install-java-8-on-mac) now:
 
+
 ```bash
 brew cask install adoptopenjdk8
 brew cask install caskroom/versions/adoptopenjdk8
@@ -203,6 +204,26 @@ $ jenv versions
   openjdk64-11.0.2
   oracle64-1.8.0.202-ea
 ```
+#### 2.1.2 Using Two JVMs on macOS using brew version 3.0+ 
+Cask locations have changed.
+
+Install latest JDK
+```bash
+brew tap homebrew/cask
+brew install brew-cask-completion
+brew tap adoptopenjdk/openjdk
+brew install --cask adoptopenjdk
+jenv add $(/usr/libexec/java_home)
+```
+
+Install another JDK
+
+```bash
+brew install --cask adoptopenjdk14
+jenv add $(/usr/libexec/java_home -v14)
+```
+
+open another terminal.
 
 #### 2.2 Other Workflows
 


### PR DESCRIPTION
Previously, the readme did not include instructions for the changes to cask. brew cask install is deprecated in favor of brew install --cask
Now, the documentation reflects latest guides to installing JENV

References to documentation are below.
https://github.com/AdoptOpenJDK/homebrew-openjdk/tree/master/Casks
https://github.com/Homebrew/homebrew-cask/blob/master/USAGE.md