### PR TITLE
Don't run jenv javahome twice in zsh

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
@@ -6,7 +6,7 @@
 
   if [ -e "$JAVA_HOME/bin/javac" ]
   then
-    export JDK_HOME=$(jenv javahome)
+    export JDK_HOME="$JAVA_HOME"
     export JENV_FORCEJDKHOME=true
   fi
  }


### PR DESCRIPTION
## Why

In bash & fish, `jenv javahome` is called only once.

https://github.com/jenv/jenv/blob/9bbc5ebfe6f38252a1a0f28897c7ae52e6a483a0/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash#L10

https://github.com/jenv/jenv/blob/9bbc5ebfe6f38252a1a0f28897c7ae52e6a483a0/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish#L7