### PR TITLE
Added installation instruction for MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,19 @@ Follow the steps below to get a working `jenv` installation with knowledge of yo
 
 #### 1.1 Installing `jenv`
 
-On OSX, the simpler way to install jEnv is using [Homebrew](https://brew.sh)
+On macOS, a simple way to install jEnv is using [Homebrew](https://brew.sh):
 
 ```bash
 brew install jenv
 ```
 
-Alternatively, and on Linux, you can install it from source :
+It's also available from [MacPorts](https://www.macports.org):
+
+```shell
+sudo port install jenv
+```
+
+Alternatively, and on Linux, you can install it from source:
 
 ```bash
 git clone https://github.com/jenv/jenv.git ~/.jenv


### PR DESCRIPTION
I've recently added a [port for jEnv to MacPorts](https://ports.macports.org/port/jenv/details/). This pull request adds info about this to jEnv's `README.md`.