### PR TITLE
Silence output before fish prompt

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
@@ -1,6 +1,6 @@
 # load jenv and enable export hook
 function __jenv_export_hook --on-event fish_prompt
-  if not command -s jenv
+  if not command -q jenv
     return
   end
   set -gx JAVA_HOME (jenv javahome)


### PR DESCRIPTION
>  -q or --query, silences the output and prints nothing, setting only the exit status. Implies --search. For compatibility with old fish versions this is also --quiet (but this is deprecated).

With `-s` every fish prompt is preceded by the path to jenv.