### PR TITLE
Skip setting `JAVA_HOME` when using system JDK

### DIFF
--- a/libexec/jenv-exec
+++ b/libexec/jenv-exec
@@ -33,7 +33,9 @@ JENV_COMMAND="$1"
 export JENV_OPTIONS="$(jenv-options)"    
 
 
-export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"    
+if [ "$JENV_VERSION" != "system" ]; then
+  export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
+fi
 
 if [ -z "$JENV_COMMAND" ]; then
   jenv-help --usage exec >&2

--- a/libexec/jenv-info
+++ b/libexec/jenv-info
@@ -32,7 +32,9 @@ export JENV_OPTIONS="$(jenv-options)"
 
 JENV_COMMAND="$1"              
 
-export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"    
+if [ "$JENV_VERSION" != "system" ]; then
+  export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
+fi
           
 
 JENV_COMMAND_PATH="$(jenv-which "$JENV_COMMAND")"

--- a/libexec/jenv-javahome
+++ b/libexec/jenv-javahome
@@ -25,6 +25,10 @@ export JENV_VERSION="$(jenv-version-name)"
 export JENV_OPTIONS="$(jenv-options)"    
 
 
-export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"    
+if [ "$JENV_VERSION" == "system" ]; then
+  echo "Using system JDK, no JAVA_HOME set!"
+  exit 1
+fi
 
+export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
 echo $JAVA_HOME


### PR DESCRIPTION
Currently `JAVA_HOME` is set to the nonexistent path `~/.jenv/versions/system` when using the `system` JDK, which causes a range of strange inconsistencies. For example, the `JAVA_HOME` will diverge from `System.getProperty("java.home")`, e.g. like this when using a Homebrew-installed OpenJDK 17 installation:

```
System.getenv("JAVA_HOME")      => "~/.jenv/versions/system"
System.getProperty("java.home") => "/opt/homebrew/Cellar/openjdk/17.0.2/libexec/openjdk.jdk/Contents/Home"
```

Additionally, invoking tools like Gradle that rely on `JAVA_HOME` from the Java application will fail since `JAVA_HOME` generally takes precedence over other methods of finding a JDK and in this case points to an invalid path.

This PR fixes this by simply not setting `JAVA_HOME` whenever the `system` JDK is used.