### PR TITLE
Improve fish support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Continue to the next section to install java.
 echo 'set PATH $HOME/.jenv/bin $PATH' >> ~/.config/fish/config.fish
 echo 'status --is-interactive; and source (jenv init -|psub)' >> ~/.config/fish/config.fish
 cp ~/.jenv/fish/jenv.fish ~/.config/fish/functions/jenv.fish
-cp ~/.jenv/fish/export.fish ~/.config/fish/functions/export.fish
 ```
 
 #### 1.2 Adding Your Java Environment

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Continue to the next section to install java.
 
 ```sh
 echo 'set PATH $HOME/.jenv/bin $PATH' >> ~/.config/fish/config.fish
-echo 'status --is-interactive; and source (jenv init -|psub)' >> ~/.config/fish/config.fish
+echo 'status --is-interactive; and jenv init - | source' >> ~/.config/fish/config.fish
 cp ~/.jenv/fish/jenv.fish ~/.config/fish/functions/jenv.fish
 ```
 

--- a/fish/export.fish
+++ b/fish/export.fish
@@ -1,4 +1,0 @@
-function export
-  set arr (echo $argv|tr = \n)
-  set -gx $arr[1] $arr[2]
-end

--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -73,7 +73,7 @@ if [ -z "$print" ]; then
     echo
     case "$shell" in
     fish )
-      echo 'status --is-interactive; and source (jenv init -|psub)'
+      echo 'status --is-interactive; and jenv init - | source'
       ;;
     * )
       echo 'eval "$(jenv init -)"'
@@ -130,7 +130,7 @@ function jenv
 
   switch "\$command"
   case ${commands[*]}
-    source (jenv "sh-\$command" \$argv|psub)
+    jenv "sh-\$command" \$argv | source
   case '*'
     command jenv "\$command" \$argv
   end


### PR DESCRIPTION
This has two changes:
1. Replacing `source (some_command | psub)` with `some_command | source`
2. Removing export.fish

The former speeds things up in the versions of fish that support piping into source. As for the latter:

Fish has had a sh-compatible export for nearly a decade now [0][1]. Unfortunately, jenv's implementation isn't fully-featured. Unlike the upstream version, it breaks on relatively-common inputs like `export X=0 Y=1`.

As fish is predominantly an interactive shell, this change shouldn't break much, especially given that only older LTS distributions versions still ship Fish 2.x in 2022.

[0]: fish-shell/fish-shell#1833
[1]: https://github.com/fish-shell/fish-shell/blob/3.4.1/share/functions/export.fish