### PR TITLE
Improve shell detection code

### DIFF
--- a/libexec/jenv-hooks
+++ b/libexec/jenv-hooks
@@ -47,7 +47,7 @@ shopt -s nullglob
 for path in ${JENV_HOOK_PATH//:/$'\n'}; do
 
   case "$shell" in
-  bash )
+  bash | * )
     for script in $path/"$JENV_COMMAND"/*.bash; do
     echo $(realpath $script)
     done

--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -22,11 +22,17 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
-  shell="${shell%% *}"
-  shell="${shell##-}"
-  shell="${shell:-$SHELL}"
-  shell="${shell##*/}"
+  if [-n "$BASH_VERSIONH"]; then
+      shell="bash"
+  elif [ -n "$ZSH_VERSION"]; then
+      shell="zsh"
+  elif [ -n "FISH_VERSION"]; then
+      shell="fish"
+  elif [ -n "KSH_VERSION"]; then
+      shell="ksh"
+  else
+      shell="unknown"
+  fi
 fi
 
 resolve_link() {

--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -95,7 +95,7 @@ fish )
   echo "set -e JAVA_HOME"
   echo "set -e JDK_HOME"
   ;;
-bash | zsh )
+bash | zsh | * )
   echo 'export PATH="'${JENV_ROOT}'/shims:${PATH}"'
   echo "export JENV_SHELL=$shell"
   echo "export JENV_LOADED=1"
@@ -137,7 +137,7 @@ function jenv
 end
 EOS
   ;;
-bash | zsh )
+bash | zsh | * )
   IFS="|"
   cat <<EOS
 jenv() {


### PR DESCRIPTION
I discovered this while trying to write tests - I want to use a Docker container to set up a clean environment for the test, but because I was running an x86 OS image on an M1 Mac, the shell detection failed.

Right now we're using `ps` to detect the shell. This is what is failing for me, since the process is `/usr/bin/qemu-x86_64 /bin/bash`. Instead, use the `$BASH_VERSION`, `$ZSH_VERSION`, etc environment variables to detect the shell.

Additionally, fix the case where the shell is unknown. When this happens, jenv init only partially runs since the shell is unknown. Since bash-derived shells are probably the most common, let's just assume that it is bash-compatible. This might still fail, but it is better than doing nothing.

