### PR TITLE
update shell detection to use more reliable current default shell rat…

### DIFF
--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -22,17 +22,11 @@ done
 
 shell="$1"
 if [ -z "$shell" ]; then
-  if [ -n "$BASH_VERSION" ]; then
-      shell="bash"
-  elif [ -n "$ZSH_VERSION" ]; then
-      shell="zsh"
-  elif [ -n "$FISH_VERSION" ]; then
-      shell="fish"
-  elif [ -n "$KSH_VERSION" ]; then
-      shell="ksh"
-  else
-      shell="unknown"
-  fi
+  shell="$(ps -p "$PPID" -o 'args=' 2>/dev/null || true)"
+  shell="${shell%% *}"
+  shell="${shell##-}"
+  shell="${shell:-$SHELL}"
+  shell="${shell##*/}"
 fi
 
 resolve_link() {


### PR DESCRIPTION
…her than shell version environment variables

Based on the [`nodenv init` implementation](https://github.com/nodenv/nodenv/blob/master/libexec/nodenv-init#L35), and fixing issues noted in #50.