### PR TITLE
Fix jenv-add shortest version for posix and osx

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -126,7 +126,7 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
     JENV_ALIAS="${JAVA_PROVIDER}${JAVA_PLATFORM}-${JAVA_VERSION}"
 
     JAVA_SHORTVERSION=$(sed 's/\([0-9]\.[0-9]\).*/\1/' <<< $JAVA_VERSION)
-    JAVA_SHORTESTVERSION=$(sed 's/\([0-9]\+\)\.\?.*/\1/' <<< $JAVA_VERSION)
+    JAVA_SHORTESTVERSION=$(sed 's/\([0-9]\{1,\}\)\.\{0,1\}.*/\1/' <<< $JAVA_VERSION)
 
     add_alias_check $JENV_ALIAS
     add_alias_check $JAVA_VERSION


### PR DESCRIPTION
POSIX/OSX don't support + or ? in BRE. Instead these need to be use
{1,} and {0,1} respectively with appropriate escaping on the braces.

Without these changes the JAVA_SHORTESTVERSION always ends up just being the sameas the JAVA_VERSION.