### PR TITLE
Fix jenv doctor exit code when no plugins are enabled

### DIFF
--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -98,7 +98,7 @@ else
   cwarn 'To fix : \techo '\''eval "$(jenv init -)"'\'' >>' "$profile"
 fi
 
-for plugin in $(ls "${JENV_ROOT}"/plugins/* 2>/dev/null); do
+for plugin in $(command ls "${JENV_ROOT}"/plugins/ 2>/dev/null); do
     pluginName=$(basename $plugin)
     targetLink=$(resolve_link $plugin)
     if [[ ! $targetLink == $JENV_INSTALL_DIR* ]]; then

--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -96,19 +96,13 @@ else
 
   cwarn "Jenv is not loaded in your $shell"
   cwarn 'To fix : \techo '\''eval "$(jenv init -)"'\'' >>' "$profile"
-
-
-
-
 fi
 
-
-	for plugin in "${JENV_ROOT}"/plugins/*; do    
-    pluginName=$(basename $plugin) 
-  	targetLink=$(resolve_link $plugin)
+for plugin in $(ls "${JENV_ROOT}"/plugins/* 2>/dev/null); do
+    pluginName=$(basename $plugin)
+    targetLink=$(resolve_link $plugin)
     if [[ ! $targetLink == $JENV_INSTALL_DIR* ]]; then
-          cwarn "Plugin $pluginName is linked to older jenv installation"
-          cfix "Please execute : jenv disable-plugin $pluginName && jenv enable-plugin $pluginName"
+        cwarn "Plugin $pluginName is linked to older jenv installation"
+        cfix "Please execute : jenv disable-plugin $pluginName && jenv enable-plugin $pluginName"
     fi
-      
-	done   
+done


### PR DESCRIPTION
Prevents globbing of JENV_ROOT/plugins/* from resulting in the literal string being used when no plugins are present in the folder. This was causing jenv doctor to fail resulting in a non-zero exit code.

Also fix some funky formatting.

Fixes #390