### PR TITLE
Fix jenv init so sh-* commands are correctly evaluated

### DIFF
--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -149,7 +149,7 @@ jenv() {
 
   case "\$command" in
   ${commands[*]})
-    eval \`jenv "sh-\$command" "\$@"\`;;
+    eval "\`jenv \"sh-\$command\" \"\$@\"\`";;
   *)
     command jenv "\$command" "\$@";;
   esac


### PR DESCRIPTION
Ensures sh-* commands which return result in more than one command have all evaluated.

Fixes #392 