### PR TITLE
Fix jenv-add with missing versions directory

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -56,6 +56,7 @@ function add_alias(){
 	cd "${JENV_JAVAPATH}"
     JENV_JAVAPATH=$PWD
     cd - 2>&1 > /dev/null
+    mkdir -p "${JENV_ROOT}/versions"
 	ln -s  "${JENV_JAVAPATH}" "${JENV_ROOT}/versions/$1"
 	touch ${JENV_ROOT}/$1.time
     cinfo "$1 added"


### PR DESCRIPTION
fixes #403 

fwiw, this code has a mix of 4-space and 1-tab indentation.