### PR TITLE
Gracefully handle `jenv add`

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -5,7 +5,7 @@ set -e
 [ -n "$JENV_DEBUG" ] && set -x
 
 if [ "$#" -eq 0 ]; then
-  jenv help add
+  jenv-help --usage add >&2
   exit 1
 fi
 

--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -4,6 +4,11 @@
 set -e
 [ -n "$JENV_DEBUG" ] && set -x
 
+if [ "$#" -eq 0 ]; then
+  jenv help add
+  exit 1
+fi
+
 # Provide jenv completions
 if [ "$1" = "--complete" ]; then
   echo "--skip-existing"


### PR DESCRIPTION
### Before
```sh
jsoref@jsoref-mbp jenv % jenv add
 is not a valid path to java installation
```

### After
```
jsoref@jsoref-mbp jenv % jenv add
Usage: jenv add /path/to/java_home

Add JDK into jenv. A alias name will be generated by parsing "java -version"
```