### PR TITLE
Use stderr for errors and diagnostics in jenv-sh-enable-plugin

### DIFF
--- a/libexec/jenv-sh-enable-plugin
+++ b/libexec/jenv-sh-enable-plugin
@@ -19,10 +19,11 @@ plugin="$1"
 
 
 if [ -h ${JENV_ROOT}/plugins/$plugin ]; then 
-	   echo "echo $plugin plugin already enabled"
+	   echo "echo $plugin plugin already enabled >&2"
+	   exit 1;
 	else
 		if [ ! -d "${JENV_INSTALL_DIR}/available-plugins/$plugin" ]; then
-  		  echo "echo $plugin plugin does not exist"
+  		  echo "echo $plugin plugin does not exist >&2"
   		  exit 1;
 		fi
  		ln -s  "${JENV_INSTALL_DIR}/available-plugins/$plugin" "${JENV_ROOT}/plugins/$plugin" 


### PR DESCRIPTION
`jenv enable-plugin` used to log "plugin already enabled" messages to stdout. This is surprising (surely it and the other error message in jenv-sh-enable-plugin should use stderr) and makes it less convenient to enable plugins in shell rc files