### PR TITLE
Fix and update the docker + bats based tests

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,6 +2,6 @@
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-docker build --tag jenv:tests $SCRIPT_DIR/test
+docker build --tag jenv:test $SCRIPT_DIR/test
 
 docker run --mount type=bind,source=$SCRIPT_DIR,target=/root/.jenv jenv:test /root/.jenv/test/bats/bin/bats /root/.jenv/test

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -4,7 +4,6 @@ RUN yum install -y https://cdn.azul.com/zulu/bin/zulu18.30.11-ca-jdk18.0.1-linux
 RUN yum install -y https://cdn.azul.com/zulu/bin/zulu18.28.13-ca-jdk18.0.0-linux.i686.rpm
 RUN yum install -y https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-linux.x86_64.rpm
 RUN yum install -y java-11-openjdk.x86_64
-RUN yum install -y java-1.6.0-openjdk.x86_64
 RUN yum install -y java-1.7.0-openjdk.x86_64
 RUN yum install -y java-1.8.0-openjdk.x86_64
 RUN yum install -y java-1.8.0-openjdk.i686

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,12 +1,14 @@
 from centos:7
 
+ARG GRAALVM_VERSION=22.3.3
+
 RUN yum install -y https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm
 RUN yum install -y zulu18-jdk
 RUN yum install -y zulu11-jdk
 RUN yum install -y java-11-openjdk
 RUN yum install -y java-1.7.0-openjdk
 RUN yum install -y java-1.8.0-openjdk
-RUN curl -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-$(arch)-22.3.3.tar.gz | tar xzf - -C /usr/lib/jvm/
+RUN curl -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-java11-linux-$(uname -m | sed 's/x86_64/amd64/')-$GRAALVM_VERSION.tar.gz | tar xzf - -C /usr/lib/jvm/
 
 RUN echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.bash_profile
 RUN echo 'eval "$(jenv init -)"' >> ~/.bash_profile

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -6,8 +6,7 @@ RUN yum install -y zulu11-jdk
 RUN yum install -y java-11-openjdk
 RUN yum install -y java-1.7.0-openjdk
 RUN yum install -y java-1.8.0-openjdk
-RUN curl -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.4/graalvm-ce-java11-linux-amd64-20.3.4.tar.gz | tar xzf - -C /usr/lib/jvm/
-RUN curl -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java11-linux-amd64-21.3.0.tar.gz | tar xzf - -C /usr/lib/jvm/
+RUN curl -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-$(arch)-22.3.3.tar.gz | tar xzf - -C /usr/lib/jvm/
 
 RUN echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.bash_profile
 RUN echo 'eval "$(jenv init -)"' >> ~/.bash_profile

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,12 +1,11 @@
 from centos:7
 
-RUN yum install -y https://cdn.azul.com/zulu/bin/zulu18.30.11-ca-jdk18.0.1-linux.x86_64.rpm
-RUN yum install -y https://cdn.azul.com/zulu/bin/zulu18.28.13-ca-jdk18.0.0-linux.i686.rpm
-RUN yum install -y https://cdn.azul.com/zulu/bin/zulu11.56.19-ca-jdk11.0.15-linux.x86_64.rpm
-RUN yum install -y java-11-openjdk.x86_64
-RUN yum install -y java-1.7.0-openjdk.x86_64
-RUN yum install -y java-1.8.0-openjdk.x86_64
-RUN yum install -y java-1.8.0-openjdk.i686
+RUN yum install -y https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm
+RUN yum install -y zulu18-jdk
+RUN yum install -y zulu11-jdk
+RUN yum install -y java-11-openjdk
+RUN yum install -y java-1.7.0-openjdk
+RUN yum install -y java-1.8.0-openjdk
 RUN curl -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.3.4/graalvm-ce-java11-linux-amd64-20.3.4.tar.gz | tar xzf - -C /usr/lib/jvm/
 RUN curl -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.3.0/graalvm-ce-java11-linux-amd64-21.3.0.tar.gz | tar xzf - -C /usr/lib/jvm/
 

--- a/test/adding_jdks.bats
+++ b/test/adding_jdks.bats
@@ -9,42 +9,51 @@ teardown() {
   rm -f ~/.jenv/versions/*
 }
 
-@test "add openjdk 1.7.0.261" {
-  jenv add /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.261-2.6.22.2.el7_8.$_ARCH/jre/
+get-build-number() {
+  local _prefix=$1
+  local _name_prefix=$(basename $_prefix)
+  basename $_prefix* | sed -E "s|$_name_prefix([0-9]+)[-.].*|\1|g"
+}
+
+@test "add openjdk 1.7.0" {
+  _BUILD_NO=$(get-build-number /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.)
+  jenv add /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.*/jre/
 
   run jenv versions
   assert_line --regexp '^ *1.7$'
-  assert_line --regexp '^ *1.7.0.261$'
-  assert_line --regexp '^ *openjdk64-1.7.0.261$'
+  assert_line --regexp "^ *1.7.0.${_BUILD_NO}$"
+  assert_line --regexp "^ *openjdk64-1.7.0.${_BUILD_NO}$"
 }
 
-@test "add openjdk 1.8.0.372" {
-  jenv add /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.372.b07-1.el7_9.$_ARCH/jre/
+@test "add openjdk 1.8.0" {
+  _BUILD_NO=$(get-build-number /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.)
+  jenv add /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.*/jre/
 
   run jenv versions
   assert_line --regexp '^ *1.8$'
-  assert_line --regexp '^ *1.8.0.372$'
-  assert_line --regexp '^ *openjdk64-1.8.0.372$'
+  assert_line --regexp "^ *1.8.0.${_BUILD_NO}$"
+  assert_line --regexp "^ *openjdk64-1.8.0.${_BUILD_NO}$"
 }
 
-@test "add openjdk 11.0.19" {
-  jenv add /usr/lib/jvm/java-11-openjdk-11.0.19.0.7-1.el7_9.$_ARCH/
+@test "add openjdk 11" {
+  _PATCH_NO=$(get-build-number /usr/lib/jvm/java-11-openjdk-11.0.)
+  jenv add /usr/lib/jvm/java-11-openjdk-11.0.*/
 
   run jenv versions
   assert_line --regexp '^ *11$'
   assert_line --regexp '^ *11.0$'
-  assert_line --regexp '^ *11.0.19$'
-  assert_line --regexp '^ *openjdk64-11.0.19$'
+  assert_line --regexp "^ *11.0.${_PATCH_NO}$"
+  assert_line --regexp "^ *openjdk64-11.0.${_PATCH_NO}$"
 }
 
-@test "add zulu 11.0.20" {
+@test "add zulu 11" {
   jenv add /usr/lib/jvm/zulu11/
 
   run jenv versions
   assert_line --regexp '^ *11$'
   assert_line --regexp '^ *11.0$'
-  assert_line --regexp '^ *11.0.20$'
-  assert_line --regexp '^ *zulu64-11.0.20$'
+  assert_line --regexp '^ *11.0.[0-9]+$'
+  assert_line --regexp '^ *zulu64-11.0.[0-9]+$'
 }
 
 @test "add zulu 18.0.2.1" {

--- a/test/adding_jdks.bats
+++ b/test/adding_jdks.bats
@@ -1,16 +1,9 @@
 #!/usr/bin/env bats
 
-setup_file() {
-  export _ARCH="$(arch)"
-}
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
 
-setup() {
-  load 'test_helper/bats-support/load'
-  load 'test_helper/bats-assert/load'
-
-  export PATH=$HOME/.jenv/bin/:$PATH
-  eval "$(jenv init -)"
-
+teardown() {
   jenv global --unset
   jenv shell --unset
   rm -f ~/.jenv/versions/*

--- a/test/adding_jdks.bats
+++ b/test/adding_jdks.bats
@@ -27,6 +27,16 @@ teardown() {
   assert_line --regexp '^ *openjdk64-1.8.0.372$'
 }
 
+@test "add openjdk 11.0.19" {
+  jenv add /usr/lib/jvm/java-11-openjdk-11.0.19.0.7-1.el7_9.$_ARCH/
+
+  run jenv versions
+  assert_line --regexp '^ *11$'
+  assert_line --regexp '^ *11.0$'
+  assert_line --regexp '^ *11.0.19$'
+  assert_line --regexp '^ *openjdk64-11.0.19$'
+}
+
 @test "add zulu 11.0.20" {
   jenv add /usr/lib/jvm/zulu11/
 
@@ -37,3 +47,22 @@ teardown() {
   assert_line --regexp '^ *zulu64-11.0.20$'
 }
 
+@test "add zulu 18.0.2.1" {
+  jenv add /usr/lib/jvm/zulu18/
+
+  run jenv versions
+  assert_line --regexp '^ *18$'
+  assert_line --regexp '^ *18.0$'
+  assert_line --regexp '^ *18.0.2.1$'
+  assert_line --regexp '^ *zulu64-18.0.2.1$'
+}
+
+@test "add graalvm 11.0.20" {
+  jenv add /usr/lib/jvm/graalvm-ce-java11-22.3.3/
+
+  run jenv versions
+  assert_line --regexp '^ *11$'
+  assert_line --regexp '^ *11.0$'
+  assert_line --regexp '^ *11.0.20$'
+  assert_line --regexp '^ *graalvm64-11.0.20$'
+}

--- a/test/adding_jdks.bats
+++ b/test/adding_jdks.bats
@@ -1,5 +1,9 @@
 #!/usr/bin/env bats
 
+setup_file() {
+  export _ARCH="$(arch)"
+}
+
 setup() {
   load 'test_helper/bats-support/load'
   load 'test_helper/bats-assert/load'
@@ -13,7 +17,7 @@ setup() {
 }
 
 @test "add openjdk 1.7.0.261" {
-  jenv add /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.261-2.6.22.2.el7_8.x86_64/jre/
+  jenv add /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.261-2.6.22.2.el7_8.$_ARCH/jre/
 
   run jenv versions
   assert_line --regexp '^ *1.7$'
@@ -21,22 +25,22 @@ setup() {
   assert_line --regexp '^ *openjdk64-1.7.0.261$'
 }
 
-@test "add openjdk 1.8.0.322" {
-  jenv add /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/
+@test "add openjdk 1.8.0.372" {
+  jenv add /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.372.b07-1.el7_9.$_ARCH/jre/
 
   run jenv versions
   assert_line --regexp '^ *1.8$'
-  assert_line --regexp '^ *1.8.0.322$'
-  assert_line --regexp '^ *openjdk64-1.8.0.322$'
+  assert_line --regexp '^ *1.8.0.372$'
+  assert_line --regexp '^ *openjdk64-1.8.0.372$'
 }
 
-@test "add zulu 11" {
-  jenv add /usr/lib/jvm/zulu-11/
+@test "add zulu 11.0.20" {
+  jenv add /usr/lib/jvm/zulu11/
 
   run jenv versions
   assert_line --regexp '^ *11$'
   assert_line --regexp '^ *11.0$'
-  assert_line --regexp '^ *11.0.15$'
-  assert_line --regexp '^ *zulu64-11.0.15$'
+  assert_line --regexp '^ *11.0.20$'
+  assert_line --regexp '^ *zulu64-11.0.20$'
 }
 

--- a/test/adding_jdks.bats
+++ b/test/adding_jdks.bats
@@ -12,15 +12,6 @@ setup() {
   rm -f ~/.jenv/versions/*
 }
 
-@test "add openjdk 1.6.0.41" {
-  jenv add /usr/lib/jvm/java-1.6.0-openjdk-1.6.0.41.x86_64/jre/
-
-  run jenv versions
-  assert_line --regexp '^ *1.6$'
-  assert_line --regexp '^ *1.6.0.41$'
-  assert_line --regexp '^ *openjdk64-1.6.0.41$'
-}
-
 @test "add openjdk 1.7.0.261" {
   jenv add /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.261-2.6.22.2.el7_8.x86_64/jre/
 

--- a/test/setting_versions.bats
+++ b/test/setting_versions.bats
@@ -63,11 +63,13 @@ teardown() {
 
   jenv global 11
 
-  output=$(jenv shell 18 && jenv version-name)
-  assert_equal $output 18
+  jenv shell 18
 
-  output=$(jenv shell 18 && realpath $(jenv javahome))
-  [ $output = "/usr/lib/jvm/zulu18-ca" ]
+  run jenv version-name
+  assert_line 18
+
+  run realpath $(jenv javahome)
+  assert_line /usr/lib/jvm/zulu18-ca
 }
 
 @test "shell sets for current shell only, reverts to global outside" {

--- a/test/setting_versions.bats
+++ b/test/setting_versions.bats
@@ -1,5 +1,8 @@
 #!/usr/bin/env bats
 
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
 setup() {
   export tmp_dir_1=`mktemp -d`
   export tmp_dir_2=`mktemp -d`
@@ -34,6 +37,7 @@ teardown() {
 
   jenv local 18
 
+  assert_equal "$(jenv version-name)" 18
   [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/zulu18-ca" ]
 }
 
@@ -49,6 +53,7 @@ teardown() {
 
   cd $tmp_dir_2
 
+  assert_equal "$(jenv version-name)" 11
   [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-22.3.3" ]
 }
 
@@ -57,7 +62,10 @@ teardown() {
   jenv add /usr/lib/jvm/zulu18/
 
   jenv global 11
-  
+
+  output=$(jenv shell 18 && jenv version-name)
+  assert_equal $output 18
+
   output=$(jenv shell 18 && realpath $(jenv javahome))
   [ $output = "/usr/lib/jvm/zulu18-ca" ]
 }
@@ -70,5 +78,6 @@ teardown() {
   
   $(jenv shell 18)
 
+  assert_equal "$(jenv version-name)" 11
   [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-22.3.3" ]
 }

--- a/test/setting_versions.bats
+++ b/test/setting_versions.bats
@@ -1,19 +1,24 @@
 #!/usr/bin/env bats
 
 setup() {
-  export PATH=$HOME/.jenv/bin/:$PATH
+  export tmp_dir_1=`mktemp -d`
+  export tmp_dir_2=`mktemp -d`
+}
 
-  eval "$(jenv init -)"
+teardown() {
   jenv global --unset
   jenv shell --unset
   rm -f ~/.jenv/versions/*
+
+  rm -rf $tmp_dir_1 $tmp_dir_2
 }
 
 @test "global version is set globally" {
   jenv add /usr/lib/jvm/graalvm-ce-java11-22.3.3/
 
   jenv global 11
-  cd `mktemp -d`
+
+  cd $tmp_dir_1
 
   assert_equal "$(jenv version-name)" 11
   [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-22.3.3" ]
@@ -25,7 +30,8 @@ setup() {
 
   jenv global 11
 
-  cd `mktemp -d`
+  cd $tmp_dir_1
+
   jenv local 18
 
   [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/zulu18-ca" ]
@@ -37,10 +43,11 @@ setup() {
 
   jenv global 11
 
-  cd `mktemp -d`
+  cd $tmp_dir_1
+
   jenv local 18
 
-  cd `mktemp -d`
+  cd $tmp_dir_2
 
   [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-22.3.3" ]
 }

--- a/test/setting_versions.bats
+++ b/test/setting_versions.bats
@@ -10,29 +10,30 @@ setup() {
 }
 
 @test "global version is set globally" {
-  jenv add /usr/lib/jvm/graalvm-ce-java11-21.3.0/
+  jenv add /usr/lib/jvm/graalvm-ce-java11-22.3.3/
 
   jenv global 11
   cd `mktemp -d`
 
-  [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-21.3.0" ]
+  assert_equal "$(jenv version-name)" 11
+  [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-22.3.3" ]
 }
 
 @test "local is set for current directory" {
-  jenv add /usr/lib/jvm/graalvm-ce-java11-21.3.0/
-  jenv add /usr/lib/jvm/zulu-18/
+  jenv add /usr/lib/jvm/graalvm-ce-java11-22.3.3/
+  jenv add /usr/lib/jvm/zulu18/
 
   jenv global 11
 
   cd `mktemp -d`
   jenv local 18
 
-  [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/zulu-18" ]
+  [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/zulu18-ca" ]
 }
 
 @test "local is set for current directory only, reverts to global" {
-  jenv add /usr/lib/jvm/graalvm-ce-java11-21.3.0/
-  jenv add /usr/lib/jvm/zulu-18/
+  jenv add /usr/lib/jvm/graalvm-ce-java11-22.3.3/
+  jenv add /usr/lib/jvm/zulu18/
 
   jenv global 11
 
@@ -41,27 +42,26 @@ setup() {
 
   cd `mktemp -d`
 
-  [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-21.3.0" ]
+  [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-22.3.3" ]
 }
 
 @test "shell sets for current shell" {
-  jenv add /usr/lib/jvm/graalvm-ce-java11-21.3.0/
-  jenv add /usr/lib/jvm/zulu-18/
+  jenv add /usr/lib/jvm/graalvm-ce-java11-22.3.3/
+  jenv add /usr/lib/jvm/zulu18/
 
   jenv global 11
   
   output=$(jenv shell 18 && realpath $(jenv javahome))
-  [ $output = "/usr/lib/jvm/zulu-18" ]
+  [ $output = "/usr/lib/jvm/zulu18-ca" ]
 }
 
 @test "shell sets for current shell only, reverts to global outside" {
-  jenv add /usr/lib/jvm/graalvm-ce-java11-21.3.0/
-  jenv add /usr/lib/jvm/zulu-18/
+  jenv add /usr/lib/jvm/graalvm-ce-java11-22.3.3/
+  jenv add /usr/lib/jvm/zulu18/
 
   jenv global 11
   
   $(jenv shell 18)
 
-  jenv global 11
-  [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-21.3.0" ]
+  [ $(realpath $(jenv javahome)) = "/usr/lib/jvm/graalvm-ce-java11-22.3.3" ]
 }

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+setup_suite() {
+  export _ARCH=$(arch)
+
+  export PATH=$HOME/.jenv/bin/:$PATH
+
+  eval "$(jenv init -)"
+
+  # TODO: this should be in jenv-init
+  export -f jenv
+}
+

--- a/test/setup_suite.bash
+++ b/test/setup_suite.bash
@@ -1,8 +1,6 @@
 #!/usr/bin/env bats
 
 setup_suite() {
-  export _ARCH=$(arch)
-
   export PATH=$HOME/.jenv/bin/:$PATH
 
   eval "$(jenv init -)"


### PR DESCRIPTION
In order to make tests green the following needed to be done:
- Fix typo in docker tag: rename to jenv:test
- Remove openjdk 1.6 and its test
- Fix `adding_jdks.bats` tests
- Fix `setting_versions.bats` tests

Additionally I added some improvements:
- Added setup_suite.bash
- Extended adding_jdks with zulu 18 and graalvm
- Refactored `setup` into: `setup_suite`, `setup` and `teardown`
- Added version-name checks to `setting_versions.bats`

Fixes #411 