### PR TITLE
Remove extra eval added by echo eval "$(jenv init -)"

### DIFF
--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -95,7 +95,7 @@ else
   esac
 
   cwarn "Jenv is not loaded in your $shell"
-  cwarn 'To fix : \techo eval "$(jenv init -)" >>' $profile
+  cwarn 'To fix : \techo '\''eval "$(jenv init -)"'\'' >>' "$profile"
 
 
 


### PR DESCRIPTION
Fixes #420

With the change, instead of 

```
eval export PATH="/Users/USERNAME/.jenv/shims:${PATH}"
export JENV_SHELL=zsh
export JENV_LOADED=1
...
```

appended to shell profile, 


```
eval "$(jenv init -)"
```

is appended instead.