### PR TITLE
Fix erroneous output in jenv jenv doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To verify `jenv` was installed, run `jenv doctor`. On a macOS machine, you'll ob
 $ jenv doctor
 [OK]	No JAVA_HOME set
 [ERROR]	Java binary in path is not in the jenv shims.
-[ERROR]	Please check your path, or try using /path/to/java/home is not a valid path to java installation.
+[ERROR]	Please check your path, or try using `jenv add /path/to/java/home`
 	PATH : /Users/user/.jenv/libexec:/Users/user/.jenv/shims:/Users/user/.jenv/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 [OK]	Jenv is correctly loaded
 ```

--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -68,7 +68,7 @@ if [ "$EXPECTED_JAVA" = "$JAVA_BIN" ] ; then
   cinfo "Java binaries in path are jenv shims"
 else
   cwarn "Java binary in path is not in the jenv shims."
-  cwarn "Please check your path, or try using `jenv add /path/to/java/home`."
+  cwarn "Please check your path, or try using \`jenv add /path/to/java/home\`."
   cfix "PATH : $PATH"
 
 fi


### PR DESCRIPTION
Ensures the jenv add text is shown rather than executed.

Previously
```
$ jenv doctor
[OK]	No JAVA_HOME set
[ERROR]	Java binary in path is not in the jenv shims.
[ERROR]	Please check your path, or try using /path/to/java/home is not a valid path to java installation.
...
```

Now
```
$ jenv doctor
[OK]	No JAVA_HOME set
[ERROR]	Java binary in path is not in the jenv shims.
[ERROR]	Please check your path, or try using `jenv add /path/to/java/home`.
```