### PR TITLE
Add installation instructions for MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,19 @@ Follow the steps below to get a working `jenv` installation with knowledge of yo
 
 #### 1.1 Installing `jenv`
 
-On macOS, the simpler way to install jEnv is using [Homebrew](https://brew.sh)
+On macOS, you can install jEnv using [Homebrew](https://brew.sh):
 
 ```bash
 brew install jenv
 ```
 
-Alternatively, and on Linux, you can install it from source :
+Or if you use [MacPorts](https://www.macports.org) on macOS:
+
+```bash
+sudo port install jenv
+```
+
+Alternatively, and on Linux, you can install it from source:
 
 ```bash
 git clone https://github.com/jenv/jenv.git ~/.jenv


### PR DESCRIPTION
This adds the installation command for [MacPorts](https://www.macports.org) users.

Note: I maintain the [jEnv port in MacPorts](https://ports.macports.org/port/jenv/), the PR for update to 0.5.7 has been submitted: https://github.com/macports/macports-ports/pull/22999.