### PR TITLE
fix: doctor resolves plugin paths correctly

### DIFF
--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -62,8 +62,6 @@ JAVA_BIN=`command -v java`
 
 EXPECTED_JAVA="$JENV_ROOT/shims/java"
 
-
-
 if [ "$EXPECTED_JAVA" = "$JAVA_BIN" ] ; then
   cinfo "Java binaries in path are jenv shims"
 else
@@ -98,11 +96,14 @@ else
   cwarn 'To fix : \techo '\''eval "$(jenv init -)"'\'' >>' "$profile"
 fi
 
-for plugin in $(command ls "${JENV_ROOT}"/plugins/ 2>/dev/null); do
-    pluginName=$(basename $plugin)
-    targetLink=$(resolve_link $plugin)
-    if [[ ! $targetLink == $JENV_INSTALL_DIR* ]]; then
+shopt -s nullglob
+for plugin in "$JENV_ROOT"/plugins/*; do
+    pluginName=$(basename "$plugin")
+    if ! targetLink=$(resolve_link "$plugin"); then
+        cwarn "Plugin $pluginName is not linked to a jenv installation"
+    elif [[ ! $targetLink == $JENV_INSTALL_DIR* ]]; then
         cwarn "Plugin $pluginName is linked to older jenv installation"
         cfix "Please execute : jenv disable-plugin $pluginName && jenv enable-plugin $pluginName"
     fi
 done
+shopt -u nullglob


### PR DESCRIPTION
A previous change meant that when doctor checked plugins it only resolved the name of the plugin and not the location. With `set -e` specified `resolve_link` would fail resulting in doctor exiting with code 1 and not performing plugin checks. This is now fixed.

Old:
```
$ jenv doctor; echo rc $?
[OK]	JAVA_HOME variable probably set by jenv PROMPT
[OK]	Java binaries in path are jenv shims
[OK]	Jenv is correctly loaded
rc 1
$ JENV_DEBUG=1 jenv doctor 2>&1 | grep basename
++ basename export
```

Fixed
```
$ jenv doctor; echo rc $?
[OK]    JAVA_HOME variable probably set by jenv PROMPT
[OK]    Java binaries in path are jenv shims
[OK]    Jenv is correctly loaded
rc 0
$ JENV_DEBUG=1 jenv doctor 2>&1 | grep basename
++ basename /Users/andrew.barnes/development/repo/github.com/jenv/jenv/plugins//export

# and with an old plugin
$ jenv doctor; echo rc $?
[OK]    JAVA_HOME variable probably set by jenv PROMPT
[OK]    Java binaries in path are jenv shims
[OK]    Jenv is correctly loaded
[ERROR] Plugin export is linked to older jenv installation
        Please execute : jenv disable-plugin export && jenv enable-plugin export
rc 0

# and a non symlink
$ jenv doctor; echo rc $?
[OK]	JAVA_HOME variable probably set by jenv PROMPT
[OK]	Java binaries in path are jenv shims
[OK]	Jenv is correctly loaded
[ERROR]	Plugin export is not linked to a jenv installation
rc 0
```