### PR TITLE
misc: Emit warning on commands if jenv not initialised/loaded

### DIFF
--- a/libexec/jenv
+++ b/libexec/jenv
@@ -99,9 +99,25 @@ shopt -u nullglob
 
 
 command="$1"
+
+case "$command" in
+  "completions" | "init" | "doctor" )
+    ;;
+  *)
+    if [[ "$JENV_LOADED" != "1" ]]
+    then
+      {
+        echo "Warning‘: jenv has not been initialised in the current shell, run"
+        echo '         eval "$(jenv init -)"'
+        echo
+      } >&2
+    fi
+    ;;
+esac
+
 case "$command" in
 "" | "-h" | "--help" )
-  echo -e "$(jenv --version)\n$(jenv-help)" >&2
+  echo -e "$(jenv---version)\n$(jenv-help)" >&2
   ;;
 * )
   command_path="$(command -v "jenv-$command" || true)"   


### PR DESCRIPTION
Resolves #175 

Should make it much clearer to newer users that they need to initialise their shell, especially on the `jenv enable-plugin export` installation step which catches people out as it is only available after initialising a shell.

Messages are written to stderr so should be backward compatible on with processes which use stdout from commands in uninitialised shells. Message is omitted on completion, iniit and doctor commands.

```
$ jenv version
Warning: jenv has not been initialised in the current shell, run
         eval "${jenv init -}"

system (set by /Users/andrew.barnes/.jenv-test/version)

$ jenv enable-plugin export
Warning: jenv has not been initialised in the current shell, run
         eval "${jenv init -}"

jenv: no such command `enable-plugin'

$ jenv add /Library/Java/JavaVirtualMachines/openjdk.jdk/Contents/Home/
Warning: jenv has not been initialised in the current shell, run
         eval "${jenv init -}"

openjdk64-21.0.2 added
21.0.2 added
21.0 added
21 added
```