### PR TITLE
fix: bug in export variables appending unnecessary args and spaces

### DIFF
--- a/available-plugins/ant/etc/jenv.d/exec/ant-before.bash
+++ b/available-plugins/ant/etc/jenv.d/exec/ant-before.bash
@@ -1,10 +1,10 @@
-if [ "$1" = "ant" ]; then            
+if [ "$1" = "ant" ]; then
   if [ -n "$JENV_OPTIONS" ]; then
     if [ -z "$ANT_OPTS" ]; then
-      exportVariable ANT_OPTS $JENV_OPTIONS
+      exportVariable ANT_OPTS "$JENV_OPTIONS"
     else
       echo "ANT_OPTS is set and not overridden by jenv"
     fi
-    unset JENV_OPTIONS        
+    unset JENV_OPTIONS
   fi
 fi

--- a/available-plugins/gradle/etc/jenv.d/exec/gradle-before.bash
+++ b/available-plugins/gradle/etc/jenv.d/exec/gradle-before.bash
@@ -1,10 +1,10 @@
-if [ "$1" = "gradle" ]; then            
+if [ "$1" = "gradle" ]; then
   if [ -n "$JENV_OPTIONS" ]; then
     if [ -z "$GRADLE_OPTS" ]; then
-      exportVariable GRADLE_OPTS $JENV_OPTIONS
+      exportVariable GRADLE_OPTS "$JENV_OPTIONS"
     else
       echo "GRADLE_OPTS is set and not overridden by jenv"
     fi
-    unset JENV_OPTIONS        
+    unset JENV_OPTIONS
   fi
 fi

--- a/available-plugins/lein/etc/jenv.d/exec/lein-before.bash
+++ b/available-plugins/lein/etc/jenv.d/exec/lein-before.bash
@@ -1,15 +1,13 @@
-if [ "$1" = "lein" ]; then  
-	exportVariable JAVA_CMD "$JAVA_HOME/bin/java"
-	exportVariable LEIN_JAVA_CMD "$JAVA_HOME/bin/java"
-
-
+if [ "$1" = "lein" ]; then
+  exportVariable JAVA_CMD "$JAVA_HOME/bin/java"
+  exportVariable LEIN_JAVA_CMD "$JAVA_HOME/bin/java"
   if [ -n "$JENV_OPTIONS" ]; then
     if [ -z "$LEIN_JVM_OPTS" ]; then
-      exportVariable LEIN_JVM_OPTS $JENV_OPTIONS
-      exportVariable JVM_OPTS $JENV_OPTIONS
+      exportVariable LEIN_JVM_OPTS "$JENV_OPTIONS"
+      exportVariable JVM_OPTS "$JENV_OPTIONS"
     else
       echo "LEIN_JVM_OPTS is set and not overridden by jenv"
     fi
-    unset JENV_OPTIONS        
-  fi      
+    unset JENV_OPTIONS
+  fi
 fi

--- a/available-plugins/maven/etc/jenv.d/exec/maven-before.bash
+++ b/available-plugins/maven/etc/jenv.d/exec/maven-before.bash
@@ -1,10 +1,10 @@
-if [ "$1" = "mvn" -o "$1" = "mvnDebug"  ]; then            
+if [ "$1" = "mvn" -o "$1" = "mvnDebug"  ]; then
   if [ -n "$JENV_OPTIONS" ]; then
     if [ -z "$MAVEN_OPTS" ]; then
-      exportVariable MAVEN_OPTS $JENV_OPTIONS
+      exportVariable MAVEN_OPTS "$JENV_OPTIONS"
     else
       echo "MAVEN_OPTS is set and not overridden by jenv"
     fi
-    unset JENV_OPTIONS        
+    unset JENV_OPTIONS
   fi
 fi

--- a/available-plugins/sbt/etc/jenv.d/exec/sbt-before.bash
+++ b/available-plugins/sbt/etc/jenv.d/exec/sbt-before.bash
@@ -1,11 +1,11 @@
-if [ "$1" = "sbt" ]; then            
+if [ "$1" = "sbt" ]; then
   if [ -n "$JENV_OPTIONS" ]; then
     if [ -z "$SBT_OPTS" ]; then
-      exportVariable SBT_OPTS $JENV_OPTIONS
+      exportVariable SBT_OPTS "$JENV_OPTIONS"
     else
       echo "SBT_OPTS is set and not overridden by jenv"
     fi
-    unset JENV_OPTIONS        
-  fi    
-  JENV_OPTIONS="$JENV_OPTIONS -java-home $JAVA_HOME"  
+    unset JENV_OPTIONS
+  fi
+  JENV_OPTIONS="$JENV_OPTIONS -java-home $JAVA_HOME"
 fi

--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -35,10 +35,8 @@ set -e
 exportedValues=""
 
 exportVariable(){
-echo $exportedValues
- #  echo $1, $2, $3
    exportedValues="$exportedValues:$1"
-   export $1="$2 $3 $4 $5 $6 $7 $8 $9"
+   export "$1"="$2"
 
 }
 

--- a/libexec/jenv-exec
+++ b/libexec/jenv-exec
@@ -11,15 +11,14 @@
 #   jenv exec java -jar myjar.jar
 #
 # is equivalent to:
-#   PATH="$JENV_ROOT/versions/oracle-1.6.3/bin:$PATH" java -jar myjar.jar 
+#   PATH="$JENV_ROOT/versions/oracle-1.6.3/bin:$PATH" java -jar myjar.jar
 
 set -e
-[ -n "$JENV_DEBUG" ] && set -x      
+[ -n "$JENV_DEBUG" ] && set -x
 
-
-exportVariable(){   
+exportVariable(){
    exportedValues="$exportedValues:$1"
-   export $1="$2 $3 $4 $5 $6 $7 $8 $9"
+   export "$1"="$2"
 }
 
 # Provide jenv completions
@@ -28,10 +27,9 @@ if [ "$1" = "--complete" ]; then
 fi
 
 export JENV_VERSION="$(jenv-version-name)"
-JENV_COMMAND="$1" 
+JENV_COMMAND="$1"
 
-export JENV_OPTIONS="$(jenv-options)"    
-
+export JENV_OPTIONS="$(jenv-options)"
 
 if [ "$JENV_VERSION" != "system" ]; then
   export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"

--- a/libexec/jenv-info
+++ b/libexec/jenv-info
@@ -5,18 +5,14 @@
 # Usage: jenv info <command>
 #
 
-
 set -e
-[ -n "$JENV_DEBUG" ] && set -x     
+[ -n "$JENV_DEBUG" ] && set -x
 
-
-            
 exportedValues=""
 
-exportVariable(){   
+exportVariable(){
    exportedValues="$exportedValues:$1"
-   export $1="$2 $3 $4 $5 $6 $7 $8 $9"
-    
+   export "$1"="$2"
 }
 
 # Provide jenv completions
@@ -24,18 +20,15 @@ if [ "$1" = "--complete" ]; then
   exec jenv shims --short
 fi
 
-export JENV_VERSION="$(jenv-version-name)"    
-            
-export JENV_OPTIONS="$(jenv-options)"    
+export JENV_VERSION="$(jenv-version-name)"
 
+export JENV_OPTIONS="$(jenv-options)"
 
-
-JENV_COMMAND="$1"              
+JENV_COMMAND="$1"
 
 if [ "$JENV_VERSION" != "system" ]; then
   export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
 fi
-          
 
 JENV_COMMAND_PATH="$(jenv-which "$JENV_COMMAND")"
 JENV_BIN_PATH="${JENV_COMMAND_PATH%/*}"
@@ -48,14 +41,13 @@ shift 1
 if [ "$JENV_VERSION" != "system" ]; then
   export PATH="${JENV_BIN_PATH}:${PATH}"
 fi
-echo "Jenv will exec : $JENV_COMMAND_PATH" $JENV_OPTIONS "$@"   
-#echo $exportedValues          
+echo "Jenv will exec : $JENV_COMMAND_PATH $JENV_OPTIONS $@"
 echo "Exported variables :"
 echo "  JAVA_HOME=$JAVA_HOME"
 while IFS=':' read -ra ADDR; do
       for i in "${ADDR[@]}"; do
       	  if [ -n "$i" ]; then
-   				echo "  $i=${!i}" 
+   				echo "  $i=${!i}"
 		  fi
       done
  done <<< "$exportedValues"

--- a/libexec/jenv-javahome
+++ b/libexec/jenv-javahome
@@ -5,13 +5,11 @@
 # Usage: jenv javahome
 #
 set -e
-[ -n "$JENV_DEBUG" ] && set -x      
+[ -n "$JENV_DEBUG" ] && set -x
 
-
-exportVariable(){   
-echo $exportedValues
+exportVariable(){
    exportedValues="$exportedValues:$1"
-   export $1="$2 $3 $4 $5 $6 $7 $8 $9"
+   export "$1"="$2"
 }
 
 # Provide jenv completions
@@ -21,9 +19,7 @@ fi
 
 export JENV_VERSION="$(jenv-version-name)"
 
-
-export JENV_OPTIONS="$(jenv-options)"    
-
+export JENV_OPTIONS="$(jenv-options)"
 
 if [ "$JENV_VERSION" == "system" ]; then
   echo "Using system JDK, no JAVA_HOME set!"
@@ -31,4 +27,4 @@ if [ "$JENV_VERSION" == "system" ]; then
 fi
 
 export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
-echo $JAVA_HOME
+echo "$JAVA_HOME"


### PR DESCRIPTION
Fixes #143 .

Internal variable exports have been corrected so they noo longer introduce trailing spaces.

This isn't (typically) an issue with things like JVM options but will cause problems when defining a path to a program/file e.g. the java program in the lein case.