### PR TITLE
Quote all references to `JENV_ROOT` variables

### DIFF
--- a/libexec/jenv
+++ b/libexec/jenv
@@ -72,7 +72,7 @@ bin_path="$(abs_dirname "$0")"
 if ! samedir "${JENV_ROOT}" "$bin_path/../"  ; then
    JENV_INSTALL_DIR=$(resolvepath "$bin_path/../")
 else
-    JENV_INSTALL_DIR=$JENV_ROOT
+    JENV_INSTALL_DIR="$JENV_ROOT"
 fi
    export JENV_INSTALL_DIR
 

--- a/libexec/jenv---version
+++ b/libexec/jenv---version
@@ -14,7 +14,7 @@ set -e
 
 version="0.5.7"
 
-if [ -d $JENV_ROOT ]; then
+if [ -d "$JENV_ROOT" ]; then
 cd "$JENV_ROOT"
 git_revision="$(git describe --tags HEAD 2>/dev/null || true)"
 git_revision="${git_revision#v}"

--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -63,7 +63,7 @@ function add_alias(){
     cd - 2>&1 > /dev/null
     mkdir -p "${JENV_ROOT}/versions"
 	ln -s  "${JENV_JAVAPATH}" "${JENV_ROOT}/versions/$1"
-	touch ${JENV_ROOT}/$1.time
+	touch "${JENV_ROOT}/$1.time"
     cinfo "$1 added"
     version_added=true
 

--- a/libexec/jenv-disable-plugin
+++ b/libexec/jenv-disable-plugin
@@ -16,7 +16,7 @@ fi
 
 plugin="$1"
 
-if [ -h ${JENV_ROOT}/plugins/$plugin ]; then
+if [ -h "${JENV_ROOT}/plugins/$plugin" ]; then
 		if [ -f "${JENV_ROOT}/plugins/$plugin/etc/jenv.d/unload/after.bash" ]; then
 			source "${JENV_ROOT}/plugins/$plugin/etc/jenv.d/unload/after.bash"
 		fi

--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -99,7 +99,7 @@ for plugin in "$JENV_ROOT"/plugins/*; do
     pluginName=$(basename "$plugin")
     if ! targetLink=$(resolve_link "$plugin"); then
         cwarn "Plugin $pluginName is not linked to a jenv installation"
-    elif [[ ! $targetLink == $JENV_INSTALL_DIR* ]]; then
+    elif [[ ! $targetLink == "$JENV_INSTALL_DIR"* ]]; then
         cwarn "Plugin $pluginName is linked to older jenv installation"
         cfix "Please execute : jenv disable-plugin $pluginName && jenv enable-plugin $pluginName"
     fi

--- a/libexec/jenv-refresh-plugins
+++ b/libexec/jenv-refresh-plugins
@@ -11,7 +11,7 @@ set -e
 FORCE_REFRESH=0
 
 if [ ! -f "${JENV_ROOT}/jenv.version" ]; then
-    echo "NONE" > ${JENV_ROOT}/jenv.version
+    echo "NONE" > "${JENV_ROOT}/jenv.version"
 fi
 
 if [ "$1" = "--complete" ]; then

--- a/libexec/jenv-remove
+++ b/libexec/jenv-remove
@@ -16,8 +16,8 @@ do
 
   if [ -L "$JENV_ROOT/versions/$JENV_VERSION" ];
   then
-    rm -f $JENV_ROOT/versions/$JENV_VERSION
-    rm -f ${JENV_ROOT}/$JENV_VERSION.time
+    rm -f "$JENV_ROOT/versions/$JENV_VERSION"
+    rm -f "${JENV_ROOT}/$JENV_VERSION.time"
     echo "JDK $JENV_VERSION removed"
 
   else

--- a/libexec/jenv-root
+++ b/libexec/jenv-root
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # Summary: Display the root directory where versions and shims are kept
-echo $JENV_ROOT
+echo "$JENV_ROOT"

--- a/libexec/jenv-sh-enable-plugin
+++ b/libexec/jenv-sh-enable-plugin
@@ -18,7 +18,7 @@ fi
 plugin="$1"
 
 
-if [ -h ${JENV_ROOT}/plugins/$plugin ]; then 
+if [ -h "${JENV_ROOT}/plugins/$plugin" ]; then 
 	   echo "echo $plugin plugin already enabled"
 	else
 		if [ ! -d "${JENV_INSTALL_DIR}/available-plugins/$plugin" ]; then


### PR DESCRIPTION
Quote all references to `JENV_ROOT` variables (and variables that use it) to avoid word splitting.

This avoids errors where `JENV_ROOT` contains spaces (e.g. `$HOME/Library/Application Support/jenv`).