### PR TITLE
chore: centos and openjdk 1.7 are both EOL, use ubi8 and openjdk 17, 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /version
 /versions
 *.time
+jenv.version
 
 # Editor directories and files
 .idea

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 
-SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+do_test() {
+  trap "rm -rf jenv.version *.time shims/ versions/" RETURN INT HUP TERM
 
-docker build --tag jenv:test $SCRIPT_DIR/test
+  SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-docker run --mount type=bind,source=$SCRIPT_DIR,target=/root/.jenv jenv:test /root/.jenv/test/bats/bin/bats /root/.jenv/test
+  if ! docker build --tag jenv:test "$SCRIPT_DIR/test"
+  then
+    echo "Failed to build the Docker image."
+    return 1
+  fi
+
+  if ! docker run --mount type=bind,source="$SCRIPT_DIR",target=/root/.jenv jenv:test /root/.jenv/test/bats/bin/bats /root/.jenv/test
+  then
+    echo "Tests failed."
+    return 1
+  fi
+}
+
+do_test

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,12 +1,13 @@
-from centos:7
+FROM redhat/ubi8
 
 ARG GRAALVM_VERSION=22.3.3
 
 RUN yum install -y https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm
 RUN yum install -y zulu18-jdk
 RUN yum install -y zulu11-jdk
+RUN yum install -y java-21-openjdk
+RUN yum install -y java-17-openjdk
 RUN yum install -y java-11-openjdk
-RUN yum install -y java-1.7.0-openjdk
 RUN yum install -y java-1.8.0-openjdk
 RUN curl -L https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-$GRAALVM_VERSION/graalvm-ce-java11-linux-$(uname -m | sed 's/x86_64/amd64/')-$GRAALVM_VERSION.tar.gz | tar xzf - -C /usr/lib/jvm/
 

--- a/test/adding_jdks.bats
+++ b/test/adding_jdks.bats
@@ -15,16 +15,6 @@ get-build-number() {
   basename $_prefix* | sed -E "s|$_name_prefix([0-9]+)[-.].*|\1|g"
 }
 
-@test "add openjdk 1.7.0" {
-  _BUILD_NO=$(get-build-number /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.)
-  jenv add /usr/lib/jvm/java-1.7.0-openjdk-1.7.0.*/jre/
-
-  run jenv versions
-  assert_line --regexp '^ *1.7$'
-  assert_line --regexp "^ *1.7.0.${_BUILD_NO}$"
-  assert_line --regexp "^ *openjdk64-1.7.0.${_BUILD_NO}$"
-}
-
 @test "add openjdk 1.8.0" {
   _BUILD_NO=$(get-build-number /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.)
   jenv add /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.*/jre/
@@ -44,6 +34,28 @@ get-build-number() {
   assert_line --regexp '^ *11.0$'
   assert_line --regexp "^ *11.0.${_PATCH_NO}$"
   assert_line --regexp "^ *openjdk64-11.0.${_PATCH_NO}$"
+}
+
+@test "add openjdk 17" {
+  _PATCH_NO=$(get-build-number /usr/lib/jvm/java-17-openjdk-17.0.)
+  jenv add /usr/lib/jvm/java-17-openjdk-17.0.*/
+
+  run jenv versions
+  assert_line --regexp '^ *17$'
+  assert_line --regexp '^ *17.0$'
+  assert_line --regexp "^ *17.0.${_PATCH_NO}$"
+  assert_line --regexp "^ *openjdk64-17.0.${_PATCH_NO}$"
+}
+
+@test "add openjdk 21" {
+  _PATCH_NO=$(get-build-number /usr/lib/jvm/java-21-openjdk-21.0.)
+  jenv add /usr/lib/jvm/java-21-openjdk-21.0.*/
+
+  run jenv versions
+  assert_line --regexp '^ *21$'
+  assert_line --regexp '^ *21.0$'
+  assert_line --regexp "^ *21.0.${_PATCH_NO}$"
+  assert_line --regexp "^ *openjdk64-21.0.${_PATCH_NO}$"
 }
 
 @test "add zulu 11" {


### PR DESCRIPTION
Also make test script more robust and cleanup created files.