### PR TITLE
 fix: when version is system don't emit error text on export hook 

### DIFF
--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.bash
@@ -2,7 +2,7 @@
 
 
  _jenv_export_hook() {
-  export JAVA_HOME=$(jenv javahome)
+  export JAVA_HOME=$(jenv javahome 2>/dev/null)
   export JENV_FORCEJAVAHOME=true
 
   if [ -e "$JAVA_HOME/bin/javac" ]

--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.fish
@@ -3,7 +3,7 @@ function __jenv_export_hook --on-event fish_prompt
   if not type -q jenv
     return
   end
-  set -gx JAVA_HOME (jenv javahome)
+  set -gx JAVA_HOME (jenv javahome 2>/dev/null)
   set -gx JENV_FORCEJAVAHOME true
 
   if test -e "$JAVA_HOME/bin/javac"

--- a/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
+++ b/available-plugins/export/etc/jenv.d/init/export_jenv_hook.zsh
@@ -1,7 +1,7 @@
 #export
 
  _jenv_export_hook() {
-  export JAVA_HOME=$(jenv javahome)
+  export JAVA_HOME=$(jenv javahome 2>/dev/null)
   export JENV_FORCEJAVAHOME=true
 
   if [ -e "$JAVA_HOME/bin/javac" ]

--- a/changelog.sh
+++ b/changelog.sh
@@ -19,7 +19,7 @@ changelog() {
     fi
 
     local changelog_details
-    changelog_details=$(git-cliff $opts "$FROM_VERSION..")
+    changelog_details=$(git-cliff $opts -- "$FROM_VERSION..")
 
     if [ -z "$changelog_details" ]
     then

--- a/libexec/jenv-javahome
+++ b/libexec/jenv-javahome
@@ -22,7 +22,7 @@ export JENV_VERSION="$(jenv-version-name)"
 export JENV_OPTIONS="$(jenv-options)"
 
 if [ "$JENV_VERSION" == "system" ]; then
-  echo "Using system JDK, no JAVA_HOME set!"
+  echo "Using system JDK, no JAVA_HOME set!" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Prevents `Using system JDK, no JAVA_HOME set!` from being emitted to the terminal on any and all commands
whenever the current jenv versions is system (e.g. `jenv local system`) and the jenv export hook is enabled.

Also fix changelog script.