### PR TITLE
Cleanup jenv-javahome

### DIFF
--- a/libexec/jenv-javahome
+++ b/libexec/jenv-javahome
@@ -7,24 +7,17 @@
 set -e
 [ -n "$JENV_DEBUG" ] && set -x
 
-exportVariable(){
-   exportedValues="$exportedValues:$1"
-   export "$1"="$2"
-}
-
 # Provide jenv completions
 if [ "$1" = "--complete" ]; then
   exec jenv shims --short
 fi
 
-export JENV_VERSION="$(jenv-version-name)"
-
-export JENV_OPTIONS="$(jenv-options)"
+JENV_VERSION="$(jenv-version-name)"
 
 if [ "$JENV_VERSION" == "system" ]; then
   echo "Using system JDK, no JAVA_HOME set!" >&2
   exit 1
 fi
 
-export JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
+JAVA_HOME="$JENV_ROOT/versions/$JENV_VERSION"
 echo "$JAVA_HOME"


### PR DESCRIPTION
Summary of changes

- remove exports. The script is invoked as a subprocess, not sourced. It's role is to print to stdout the path to JVM home
- as an intentional side effect of removing export, `jenv-javahome` now exits with non-zero status when `jenv-version-name` fails
- remove invocation of `jenv-options` as the result was unused
