### PR TITLE
feat: support bellsoft/liberica versions

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -115,6 +115,7 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
             *Semeru\ Runtime\ Certified*)       JAVA_PROVIDER="semeru_certified" ;;
             *Dragonwell*)                       JAVA_PROVIDER="dragonwell" ;;
             *J9*)                               JAVA_PROVIDER="ibm" ;;
+            *Liberica*)                         JAVA_PROVIDER="bellsoft" ;;
             *OpenJDK*)                          JAVA_PROVIDER="openjdk" ;;
             *)                                  JAVA_PROVIDER="other" ;;
         esac


### PR DESCRIPTION
```
$ jenv add ~/.sdkman/candidates/java/25.0.1.r25-nik/
bellsoft64-25.0.1 added
 25.0.1 already present, skip installation
 25.0 already present, skip installation
 25 already present, skip installation

$ jenv versions --verbose | grep -A2 bell
  bellsoft64-25.0.1
         /Users/xxxxxx/.jenv/versions/bellsoft64-25.0.1
         --> /Users/xxxxxx/.sdkman/candidates/java/25.0.1.r25-nik
```