### PR TITLE
fix: ensure graalvm detected before hotspot

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -99,10 +99,10 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
         JAVA_VERSION=${JAVA_VERSION/_/.}
 
         case "${JAVA_VERSION_OUTPUT}" in
+            *GraalVM*)                          JAVA_PROVIDER="graalvm" ;;
             *HotSpot*)                          JAVA_PROVIDER="oracle" ;;
             *Zulu*)                             JAVA_PROVIDER="zulu" ;;
             *Zing*)                             JAVA_PROVIDER="zulu_prime" ;;
-            *GraalVM*)                          JAVA_PROVIDER="graalvm" ;;
             *Corretto*)                         JAVA_PROVIDER="corretto" ;;
             *sapmachine*)                       JAVA_PROVIDER="sap" ;;
             *SapMachine*)                       JAVA_PROVIDER="sap" ;;


### PR DESCRIPTION
```
$ ~/.sdkman/candidates/java/21.0.9-graal/bin/java -version
java version "21.0.9" 2025-10-21 LTS
Java(TM) SE Runtime Environment Oracle GraalVM 21.0.9+7.1 (build 21.0.9+7-LTS-jvmci-23.1-b79)
Java HotSpot(TM) 64-Bit Server VM Oracle GraalVM 21.0.9+7.1 (build 21.0.9+7-LTS-jvmci-23.1-b79, mixed mode, sharing)

$ jenv add ~/.sdkman/candidates/java/21.0.9-graal
graalvm64-21.0.9 added
 21.0.9 already present, skip installation
 21.0 already present, skip installation
 21 already present, skip installation
```