### PR TITLE
fix: correctly detect 32/64 bit

### DIFF
--- a/libexec/jenv-add
+++ b/libexec/jenv-add
@@ -121,7 +121,7 @@ if [ -f "${JENV_JAVAPATH}/bin/java" ]; then
         esac
     fi;
 
-    if [ $JAVA_PROVIDER=="sap" ]; then
+    if [ "$JAVA_PROVIDER" == "sap" ]; then
         JAVA_PLATFORM="64"
     else
         if "${JENV_JAVAPATH}/bin/java" -version 2>&1 | grep -q "64-Bit"; then


### PR DESCRIPTION
Fixes #276 

Corrects the test for sap - without spaces this was just testing for a non-empty string which always evaluated to true.

Tested against a dummy `java` file which was just a shell script echoing version info

```
$ ~/.sdkman/candidates/java/21.0.9-graal/bin/java -version
java version "21.0.9" 2025-10-21 LTSA
Java(TM) SE Runtime Environment Oracle GraalVM 21.0.9+7.1 (build 21.0.9+7-LTS-jvmci-23.1-b79)A
Java HotSpot(TM) 32-Bit Server VM Oracle GraalVM 21.0.9+7.1 (build 21.0.9+7-LTS-jvmci-23.1-b79, mixed mode, sharing)

$ jenv add ~/.sdkman/candidates/java/21.0.9-graal/
graalvm32-21.0.9 added
 21.0.9 already present, skip installation
 21.0 already present, skip installation
 21 already present, skip installation
```