### PR TITLE
fix: add symlink check before calling readlink for uutils compatibility

### DIFF
--- a/libexec/jenv
+++ b/libexec/jenv
@@ -3,7 +3,9 @@ set -e
 [ -n "$JENV_DEBUG" ] && set -x
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) "$1"
+  if [ -L "$1" ]; then
+    $(type -p greadlink readlink | head -1) "$1"
+  fi
 }
 
 abs_dirname() {

--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -26,7 +26,9 @@ function cfix() {
 }
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) "$1"
+  if [ -L "$1" ]; then
+    $(type -p greadlink readlink | head -1) "$1"
+  fi
 }
 
 set -e

--- a/libexec/jenv-hooks
+++ b/libexec/jenv-hooks
@@ -25,7 +25,9 @@ if [ -z $shell ]; then
 fi
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) $1
+  if [ -L "$1" ]; then
+    $(type -p greadlink readlink | head -1) "$1"
+  fi
 }
 
 realpath() {

--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -30,7 +30,9 @@ if [ -z "$shell" ]; then
 fi
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) $1
+  if [ -L "$1" ]; then
+    $(type -p greadlink readlink | head -1) "$1"
+  fi
 }
 
 abs_dirname() {

--- a/libexec/jenv-plugins
+++ b/libexec/jenv-plugins
@@ -14,7 +14,9 @@ fi
 
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) "$1"
+  if [ -L "$1" ]; then
+    $(type -p greadlink readlink | head -1) "$1"
+  fi
 }
 
 samedir()  {

--- a/libexec/jenv-refresh-plugins
+++ b/libexec/jenv-refresh-plugins
@@ -2,7 +2,9 @@
 # Summary: Refresh plugins links
 
 resolve_link() {
-  $(type -p greadlink readlink | head -1) "$1"
+  if [ -L "$1" ]; then
+    $(type -p greadlink readlink | head -1) "$1"
+  fi
 }       
                   
 set -e

--- a/libexec/jenv-refresh-versions
+++ b/libexec/jenv-refresh-versions
@@ -2,7 +2,9 @@
 # Summary: Refresh alias names
      
 resolve_link() {
-  $(type -p greadlink readlink | head -1) "$1"
+  if [ -L "$1" ]; then
+    $(type -p greadlink readlink | head -1) "$1"
+  fi
 }       
                   
 set -e


### PR DESCRIPTION
The uutils/coreutils implementation of readlink emits error messages to stderr when invoked on non-symlinks (regular files or directories):

  readlink: <file>: Invalid argument

By contrast, BSD and GNU readlink fail silently. This caused unwanted error output when using jenv with uutils/coreutils.

The resolve_link() function is used in abs_dirname() to traverse paths, and may be called on non-symlinks during normal operation. This fix adds a symlink check using [ -L "$1" ] before invoking readlink, which:

- Prevents spurious error messages from uutils readlink
- Maintains compatibility with BSD, GNU, and uutils implementations
- Preserves real error visibility by only calling readlink on symlinks
- Avoids the need to suppress stderr which would hide genuine errors