### PR TITLE
fix: force PATH search when resolving greadlink and readlink

### DIFF
--- a/libexec/jenv
+++ b/libexec/jenv
@@ -4,7 +4,7 @@ set -e
 
 resolve_link() {
   if [ -L "$1" ]; then
-    $(type -p greadlink readlink | head -1) "$1"
+    $(type -P greadlink readlink | head -1) "$1"
   fi
 }
 

--- a/libexec/jenv-doctor
+++ b/libexec/jenv-doctor
@@ -27,7 +27,7 @@ function cfix() {
 
 resolve_link() {
   if [ -L "$1" ]; then
-    $(type -p greadlink readlink | head -1) "$1"
+    $(type -P greadlink readlink | head -1) "$1"
   fi
 }
 

--- a/libexec/jenv-hooks
+++ b/libexec/jenv-hooks
@@ -26,7 +26,7 @@ fi
 
 resolve_link() {
   if [ -L "$1" ]; then
-    $(type -p greadlink readlink | head -1) "$1"
+    $(type -P greadlink readlink | head -1) "$1"
   fi
 }
 

--- a/libexec/jenv-init
+++ b/libexec/jenv-init
@@ -31,7 +31,7 @@ fi
 
 resolve_link() {
   if [ -L "$1" ]; then
-    $(type -p greadlink readlink | head -1) "$1"
+    $(type -P greadlink readlink | head -1) "$1"
   fi
 }
 

--- a/libexec/jenv-plugins
+++ b/libexec/jenv-plugins
@@ -15,7 +15,7 @@ fi
 
 resolve_link() {
   if [ -L "$1" ]; then
-    $(type -p greadlink readlink | head -1) "$1"
+    $(type -P greadlink readlink | head -1) "$1"
   fi
 }
 

--- a/libexec/jenv-refresh-plugins
+++ b/libexec/jenv-refresh-plugins
@@ -3,7 +3,7 @@
 
 resolve_link() {
   if [ -L "$1" ]; then
-    $(type -p greadlink readlink | head -1) "$1"
+    $(type -P greadlink readlink | head -1) "$1"
   fi
 }       
                   

--- a/libexec/jenv-refresh-versions
+++ b/libexec/jenv-refresh-versions
@@ -3,7 +3,7 @@
      
 resolve_link() {
   if [ -L "$1" ]; then
-    $(type -p greadlink readlink | head -1) "$1"
+    $(type -P greadlink readlink | head -1) "$1"
   fi
 }       
                   


### PR DESCRIPTION
If greadlink (or readlink) are available in the shell as an exported function `type -p` will print nothing. This shifts to using `type -P` to ensure we look for executable files on the PATH.

```
$ greadlink() { :; }

$ type -p greadlink

$ type -P greadlink
/usr/local/bin/greadlink
```