### PR TITLE
fix: shellcheck issues in jenv-info and minor formatting changes

### DIFF
--- a/libexec/jenv-info
+++ b/libexec/jenv-info
@@ -11,8 +11,8 @@ set -e
 exportedValues=""
 
 exportVariable(){
-   exportedValues="$exportedValues:$1"
-   export "$1"="$2"
+  exportedValues="$exportedValues:$1"
+  export "$1"="$2"
 }
 
 # Provide jenv completions
@@ -20,9 +20,11 @@ if [ "$1" = "--complete" ]; then
   exec jenv shims --short
 fi
 
-export JENV_VERSION="$(jenv-version-name)"
+JENV_VERSION="$(jenv-version-name)"
+export JENV_VERSION
 
-export JENV_OPTIONS="$(jenv-options)"
+JENV_OPTIONS="$(jenv-options)"
+export JENV_OPTIONS
 
 JENV_COMMAND="$1"
 
@@ -34,20 +36,24 @@ JENV_COMMAND_PATH="$(jenv-which "$JENV_COMMAND")"
 JENV_BIN_PATH="${JENV_COMMAND_PATH%/*}"
 
 for script in $(jenv-hooks exec); do
+  # shellcheck source=/dev/null
   source "$script"
 done
 
 shift 1
+
 if [ "$JENV_VERSION" != "system" ]; then
   export PATH="${JENV_BIN_PATH}:${PATH}"
 fi
-echo "Jenv will exec : $JENV_COMMAND_PATH $JENV_OPTIONS $@"
+
+echo "Jenv will exec : $JENV_COMMAND_PATH $JENV_OPTIONS $*"
 echo "Exported variables :"
 echo "  JAVA_HOME=$JAVA_HOME"
+
 while IFS=':' read -ra ADDR; do
-      for i in "${ADDR[@]}"; do
-      	  if [ -n "$i" ]; then
-   				echo "  $i=${!i}"
-		  fi
-      done
- done <<< "$exportedValues"
+  for i in "${ADDR[@]}"; do
+    if [ -n "$i" ]; then
+      echo "  $i=${!i}"
+    fi
+  done
+done <<< "$exportedValues"


### PR DESCRIPTION
Addressed issues:
```
In libexec/jenv-info line 23:
export JENV_VERSION="$(jenv-version-name)"
       ^----------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

In libexec/jenv-info line 25:
export JENV_OPTIONS="$(jenv-options)"
       ^----------^ SC2155 (warning): Declare and assign separately to avoid masking return values.

In libexec/jenv-info line 37:
  source "$script"
         ^-------^ SC1090 (warning): ShellCheck can't follow non-constant source. Use a directive to specify location.

In libexec/jenv-info line 44:
echo "Jenv will exec : $JENV_COMMAND_PATH $JENV_OPTIONS $@"
                                                        ^-- SC2145 (error): Argument mixes string and array. Use * or separate argument.
```